### PR TITLE
Define inet256.Addr as separate type from p2p.PeerID

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ A 256 bit address space for peer-to-peer hosts/applications.
 - Messages are never corrupted. If it gets there, it's correct.
 - Easy to add/remove/change routing algorithms.
 - Addresses are plentiful. Spawn a new node for each process. Every process gets its own address, no need for ports.
-- IPv6 Portal for IPv6 over INET256. Exposed as a TUN device.
+- Daemon can run without root or `NET_ADMIN` capability.
+- IPv6 Portal for IPv6 over INET256. Exposed as a TUN device. (requires `NET_ADMIN`).
 - Autopeering and transport address discovery help make peering easy.
 
 ## Network Routing Protocols

--- a/client/go_client/inet256client/client.go
+++ b/client/go_client/inet256client/client.go
@@ -93,14 +93,18 @@ func (c *client) MainAddr() inet256.Addr {
 	return inet256.AddrFromBytes(res.LocalAddr)
 }
 
-func (c *client) TransportAddrs() []string {
+func (c *client) TransportAddrs() []p2p.Addr {
 	ctx := context.Background()
 	res, err := c.manageClient.GetStatus(ctx, &emptypb.Empty{})
 	if err != nil {
 		c.log.Error(err)
 		return nil
 	}
-	return res.GetTransportAddrs()
+	var ret []p2p.Addr
+	for _, addr := range res.TransportAddrs {
+		ret = append(ret, TransportAddr(addr))
+	}
+	return ret
 }
 
 func (c *client) PeerStatus() []inet256srv.PeerStatus {
@@ -111,4 +115,18 @@ func (c *client) PeerStatus() []inet256srv.PeerStatus {
 		return nil
 	}
 	return inet256grpc.PeerStatusFromProto(req.PeerStatus)
+}
+
+type TransportAddr string
+
+func (a TransportAddr) MarshalText() ([]byte, error) {
+	return []byte(a), nil
+}
+
+func (a TransportAddr) Key() string {
+	return string(a)
+}
+
+func (a TransportAddr) String() string {
+	return string(a)
 }

--- a/client/go_client/inet256client/node.go
+++ b/client/go_client/inet256client/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/inet256/inet256/pkg/inet256grpc"
 	"github.com/inet256/inet256/pkg/inet256srv"
+	"github.com/inet256/inet256/pkg/serde"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -44,7 +45,7 @@ func newNode(inetClient inet256grpc.INET256Client, privKey p2p.PrivateKey) (*nod
 		cf:         cf,
 		inetClient: inetClient,
 		privKey:    privKey,
-		localAddr:  p2p.NewPeerID(privKey.Public()),
+		localAddr:  inet256.NewAddr(privKey.Public()),
 		recvHub:    inet256srv.NewTellHub(),
 		workers:    make([]*worker, runtime.GOMAXPROCS(0)),
 	}
@@ -126,7 +127,7 @@ func (n *node) connect(ctx context.Context) (inet256grpc.INET256_ConnectClient, 
 	if err != nil {
 		return nil, err
 	}
-	privKeyBytes, err := inet256.MarshalPrivateKey(n.privKey)
+	privKeyBytes, err := serde.MarshalPrivateKey(n.privKey)
 	if err != nil {
 		panic(err)
 	}

--- a/client/go_client/inet256client/util.go
+++ b/client/go_client/inet256client/util.go
@@ -6,6 +6,7 @@ import (
 	"github.com/inet256/inet256/pkg/inet256"
 )
 
+// NewPacketConn wraps the Network n in an adapter exposing the net.PacketConn interface instead.
 func NewPacketConn(n inet256.Network) net.PacketConn {
 	return inet256.NewPacketConn(n)
 }

--- a/client/go_client/inet256client/util.go
+++ b/client/go_client/inet256client/util.go
@@ -1,0 +1,11 @@
+package inet256client
+
+import (
+	"net"
+
+	"github.com/inet256/inet256/pkg/inet256"
+)
+
+func NewPacketConn(n inet256.Network) net.PacketConn {
+	return inet256.NewPacketConn(n)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/inet256/inet256
 go 1.15
 
 require (
-	github.com/brendoncarroll/go-p2p v0.0.0-20210712024046-22caa1e12d19
+	github.com/brendoncarroll/go-p2p v0.0.0-20210717192809-e3d7a4b20bf2
 	github.com/golang/protobuf v1.4.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bkaradzic/go-lz4 v0.0.0-20160924222819-7224d8d8f27e h1:2augTYh6E+XoNrrivZJBadpThP/dsvYKj0nzqfQ8tM4=
 github.com/bkaradzic/go-lz4 v0.0.0-20160924222819-7224d8d8f27e/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
-github.com/brendoncarroll/go-p2p v0.0.0-20210712024046-22caa1e12d19 h1:CK8Dvnj6mudBvUgT9pN96tIMYbnvL9H30V6j8tNmZmo=
-github.com/brendoncarroll/go-p2p v0.0.0-20210712024046-22caa1e12d19/go.mod h1:0vMrP9usF5q1T4o0o37QvcEOFyB2gSKXf+7mldLHxMw=
+github.com/brendoncarroll/go-p2p v0.0.0-20210717192809-e3d7a4b20bf2 h1:6AhA4gr34CsVg+alNJa8+bfeVYW1tZMXC7C5OaGThug=
+github.com/brendoncarroll/go-p2p v0.0.0-20210717192809-e3d7a4b20bf2/go.mod h1:0vMrP9usF5q1T4o0o37QvcEOFyB2gSKXf+7mldLHxMw=
 github.com/brendoncarroll/go-state v0.0.0-20210627233638-99c825eb7040 h1:I46IjykpWXCBYWVWGX8wqX7YCGWoAEY48+aR3p9tpak=
 github.com/brendoncarroll/go-state v0.0.0-20210627233638-99c825eb7040/go.mod h1:EQKdXJyc93dh3yN1wRYdKjAZk+MutF5DFwoW+Vqe5U0=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=

--- a/networks/floodnet/floodnet.go
+++ b/networks/floodnet/floodnet.go
@@ -23,18 +23,18 @@ type Addr = inet256.Addr
 
 type Network struct {
 	localAddr  inet256.Addr
-	privateKey p2p.PrivateKey
+	privateKey inet256.PrivateKey
 	onehop     inet256.PeerSet
 	swarm      inet256.Swarm
 	log        *inet256.Logger
 
 	mu    sync.RWMutex
-	peers map[Addr]p2p.PublicKey
+	peers map[Addr]inet256.PublicKey
 
 	recvHub *inet256srv.TellHub
 }
 
-func New(privateKey p2p.PrivateKey, ps inet256.Swarm, onehop inet256.PeerSet, log *inet256.Logger) inet256.Network {
+func New(privateKey inet256.PrivateKey, ps inet256.Swarm, onehop inet256.PeerSet, log *inet256.Logger) inet256.Network {
 	n := &Network{
 		localAddr:  inet256.NewAddr(privateKey.Public()),
 		privateKey: privateKey,
@@ -42,7 +42,7 @@ func New(privateKey p2p.PrivateKey, ps inet256.Swarm, onehop inet256.PeerSet, lo
 		swarm:      ps,
 		log:        log,
 
-		peers:   make(map[Addr]p2p.PublicKey),
+		peers:   make(map[Addr]inet256.PublicKey),
 		recvHub: inet256srv.NewTellHub(),
 	}
 	go func() {
@@ -195,7 +195,7 @@ func (n *Network) fromBelow(ctx context.Context, from inet256.Addr, msg Message)
 	return n.forward(ctx, from, msg)
 }
 
-func (n *Network) addPeer(pubKey p2p.PublicKey) {
+func (n *Network) addPeer(pubKey inet256.PublicKey) {
 	src := inet256.NewAddr(pubKey)
 	n.mu.Lock()
 	n.peers[src] = pubKey

--- a/pkg/autopeering/api.go
+++ b/pkg/autopeering/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/brendoncarroll/go-p2p"
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/sirupsen/logrus"
 )
@@ -11,12 +12,16 @@ import (
 type PeerStore = inet256.PeerStore
 
 // AddrSource returns a list of addresses suitable for advertisement.
-type AddrSource = func() []string
+type AddrSource = func() []p2p.Addr
 
 type Params struct {
+	// Outbound
 	LocalAddr  inet256.Addr
-	PeerStore  PeerStore
 	AddrSource AddrSource
+
+	// Inbound
+	PeerStore PeerStore
+	ParseAddr func([]byte) (p2p.Addr, error)
 }
 
 // Service manages the peers in a PeerStore, adding to and removing from them automatically

--- a/pkg/discovery/api.go
+++ b/pkg/discovery/api.go
@@ -1,5 +1,14 @@
 package discovery
 
-import "github.com/brendoncarroll/go-p2p"
+import (
+	"context"
+	"time"
 
-type Service = p2p.DiscoveryService
+	"github.com/brendoncarroll/go-p2p"
+	"github.com/inet256/inet256/pkg/inet256"
+)
+
+type Service interface {
+	Find(ctx context.Context, x inet256.Addr) ([]p2p.Addr, error)
+	Announce(ctx context.Context, x inet256.Addr, addrs []p2p.Addr, ttl time.Duration) error
+}

--- a/pkg/discovery/celldisco/celldisco.go
+++ b/pkg/discovery/celldisco/celldisco.go
@@ -1,10 +1,7 @@
 package celldisco
 
-import (
-	"github.com/brendoncarroll/go-p2p"
-	"github.com/brendoncarroll/go-p2p/d/celltracker"
-)
+import "github.com/inet256/inet256/pkg/discovery"
 
-func New(token string) (p2p.DiscoveryService, error) {
-	return celltracker.NewClient(token)
+func New(token string) (discovery.Service, error) {
+	panic("not implemented")
 }

--- a/pkg/discovery/landisco/message.go
+++ b/pkg/discovery/landisco/message.go
@@ -4,7 +4,7 @@ import (
 	"crypto/hmac"
 	"math/rand"
 
-	"github.com/brendoncarroll/go-p2p"
+	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/sha3"
@@ -18,7 +18,7 @@ const MinMessageSize = 32 + 32
 
 type Message []byte
 
-func NewMessage(id p2p.PeerID, payload []byte) Message {
+func NewMessage(id inet256.Addr, payload []byte) Message {
 	ciph, err := chacha20poly1305.NewX(id[:])
 	if err != nil {
 		panic(err)
@@ -80,7 +80,7 @@ func copy32(x []byte) [32]byte {
 	return y
 }
 
-func UnpackMessage(m Message, ids []p2p.PeerID) (int, []byte, error) {
+func UnpackMessage(m Message, ids []inet256.Addr) (int, []byte, error) {
 	mac := m.GetMAC()
 	nonce := m.GetNonce()
 	preimage := [64]byte{}

--- a/pkg/discovery/landisco/message_test.go
+++ b/pkg/discovery/landisco/message_test.go
@@ -4,7 +4,7 @@ import (
 	mrand "math/rand"
 	"testing"
 
-	"github.com/brendoncarroll/go-p2p"
+	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,8 +19,8 @@ func TestMessage(t *testing.T) {
 	require.Equal(t, 9, n)
 }
 
-func generatePeerIDs(n int) []p2p.PeerID {
-	ids := make([]p2p.PeerID, n)
+func generatePeerIDs(n int) []inet256.Addr {
+	ids := make([]inet256.Addr, n)
 	for i := range ids {
 		mrand.Read(ids[i][:])
 	}

--- a/pkg/inet256/addr.go
+++ b/pkg/inet256/addr.go
@@ -12,7 +12,7 @@ type (
 
 // Addr is an address in an INET256 Network.
 // It uniquely identifies a Node.
-type Addr p2p.PeerID
+type Addr [32]byte
 
 // NewAddr creates a new Addr from a PublicKey
 func NewAddr(pubKey PublicKey) Addr {

--- a/pkg/inet256/network.go
+++ b/pkg/inet256/network.go
@@ -16,7 +16,7 @@ type Message struct {
 	Payload []byte
 }
 
-// Swarm is the type of a p2p.Swarm which uses p2p.PeerIDs as addresses
+// Swarm is similar to a p2p.Swarm, but uses inet256.Addrs instead of p2p.Addrs
 type Swarm interface {
 	Tell(ctx context.Context, dst Addr, m p2p.IOVec) error
 	Recv(ctx context.Context, src, dst *Addr, buf []byte) (int, error)
@@ -27,7 +27,7 @@ type Swarm interface {
 }
 
 const (
-	// TransportMTU is the gaurenteed MTU presented to networks.
+	// TransportMTU is the guaranteed MTU presented to networks.
 	TransportMTU = (1 << 16) - 1
 
 	// MinMTU is the minimum MTU a network can provide to any address

--- a/pkg/inet256/network.go
+++ b/pkg/inet256/network.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/brendoncarroll/go-p2p"
-	"github.com/brendoncarroll/go-p2p/s/peerswarm"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,13 +16,23 @@ type Message struct {
 	Payload []byte
 }
 
-// PeerSwarm is the type of a p2p.Swarm which uses p2p.PeerIDs as addresses
-type PeerSwarm = peerswarm.Swarm
+// Swarm is the type of a p2p.Swarm which uses p2p.PeerIDs as addresses
+type Swarm interface {
+	Tell(ctx context.Context, dst Addr, m p2p.IOVec) error
+	Recv(ctx context.Context, src, dst *Addr, buf []byte) (int, error)
+
+	Close() error
+	LookupPublicKey(ctx context.Context, addr Addr) (PublicKey, error)
+	LocalAddr() Addr
+}
 
 const (
+	// TransportMTU is the gaurenteed MTU presented to networks.
 	TransportMTU = (1 << 16) - 1
 
+	// MinMTU is the minimum MTU a network can provide to any address
 	MinMTU = 1 << 15
+	// MaxMTU is the largest message that a network will ever receive from any address.
 	MaxMTU = 1 << 16
 )
 
@@ -35,7 +44,7 @@ type Network interface {
 	LocalAddr() Addr
 	MTU(ctx context.Context, addr Addr) int
 
-	LookupPublicKey(ctx context.Context, addr Addr) (p2p.PublicKey, error)
+	LookupPublicKey(ctx context.Context, addr Addr) (PublicKey, error)
 	FindAddr(ctx context.Context, prefix []byte, nbits int) (Addr, error)
 
 	Bootstrap(ctx context.Context) error
@@ -46,8 +55,8 @@ type Network interface {
 // This type really defines the problem domain quite well. Essentially
 // it is a set of one-hop peers and a means to send messages to them.
 type NetworkParams struct {
-	PrivateKey p2p.PrivateKey
-	Swarm      PeerSwarm
+	PrivateKey PrivateKey
+	Swarm      Swarm
 	Peers      PeerSet
 
 	Logger *Logger

--- a/pkg/inet256/packetconn.go
+++ b/pkg/inet256/packetconn.go
@@ -1,0 +1,107 @@
+package inet256
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type packetConn struct {
+	n Network
+
+	mu                          sync.RWMutex
+	readDeadline, writeDeadline *time.Time
+}
+
+func NewPacketConn(n Network) net.PacketConn {
+	return &packetConn{n: n}
+}
+
+func (pc *packetConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	dst, err := convertAddr(addr)
+	if err != nil {
+		return 0, err
+	}
+	ctx, cf := pc.getWriteContext()
+	defer cf()
+	if err = pc.n.Tell(ctx, dst, p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (pc *packetConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	var src, dst Addr
+	ctx, cf := pc.getReadContext()
+	defer cf()
+	n, err = pc.n.Recv(ctx, &src, &dst, p)
+	if err != nil {
+		return n, nil, err
+	}
+	return n, src, nil
+}
+
+func (pc *packetConn) LocalAddr() net.Addr {
+	return pc.n.LocalAddr()
+}
+
+func (pc *packetConn) Close() error {
+	return pc.n.Close()
+}
+
+func (pc *packetConn) SetDeadline(t time.Time) error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.readDeadline = &t
+	pc.writeDeadline = &t
+	return nil
+}
+
+func (pc *packetConn) SetWriteDeadline(t time.Time) error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.writeDeadline = &t
+	return nil
+}
+
+func (pc *packetConn) SetReadDeadline(t time.Time) error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.readDeadline = &t
+	return nil
+}
+
+func (pc *packetConn) getReadContext() (context.Context, context.CancelFunc) {
+	ctx := context.Background()
+	pc.mu.RLock()
+	dl := pc.readDeadline
+	pc.mu.RUnlock()
+	if dl != nil {
+		return context.WithDeadline(ctx, *dl)
+	} else {
+		return context.WithCancel(ctx)
+	}
+}
+
+func (pc *packetConn) getWriteContext() (context.Context, context.CancelFunc) {
+	ctx := context.Background()
+	pc.mu.RLock()
+	dl := pc.writeDeadline
+	pc.mu.RUnlock()
+	if dl != nil {
+		return context.WithDeadline(ctx, *dl)
+	} else {
+		return context.WithCancel(ctx)
+	}
+}
+
+func convertAddr(x net.Addr) (Addr, error) {
+	y, ok := x.(Addr)
+	if !ok {
+		return Addr{}, errors.Errorf("invalid address: %v", x)
+	}
+	return y, nil
+}

--- a/pkg/inet256/peers.go
+++ b/pkg/inet256/peers.go
@@ -4,16 +4,16 @@ import "github.com/brendoncarroll/go-p2p"
 
 // PeerStore stores information about peers
 type PeerStore interface {
-	Add(id p2p.PeerID)
-	Remove(id p2p.PeerID)
-	SetAddrs(id p2p.PeerID, addrs []string)
-	ListAddrs(p2p.PeerID) []string
+	Add(x Addr)
+	Remove(x Addr)
+	SetAddrs(x Addr, addrs []p2p.Addr)
+	ListAddrs(x Addr) []p2p.Addr
 
 	PeerSet
 }
 
 // PeerSet represents a set of peers
 type PeerSet interface {
-	ListPeers() []p2p.PeerID
-	Contains(p2p.PeerID) bool
+	ListPeers() []Addr
+	Contains(Addr) bool
 }

--- a/pkg/inet256/service.go
+++ b/pkg/inet256/service.go
@@ -9,7 +9,7 @@ import (
 type Node interface {
 	Network
 
-	ListOneHop() []p2p.PeerID
+	ListOneHop() []Addr
 }
 
 type Service interface {

--- a/pkg/inet256cmd/keygen.go
+++ b/pkg/inet256cmd/keygen.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brendoncarroll/go-p2p"
 	"github.com/inet256/inet256/pkg/inet256"
+	"github.com/inet256/inet256/pkg/serde"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +21,7 @@ var keygenCmd = &cobra.Command{
 	Short: "generates a private key and writes it to stdout",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		privKey := generateKey()
-		data, err := inet256.MarshalPrivateKeyPEM(privKey)
+		data, err := serde.MarshalPrivateKeyPEM(privKey)
 		if err != nil {
 			return err
 		}
@@ -38,7 +39,7 @@ var deriveAddrCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		privateKey, err := inet256.ParsePrivateKeyPEM(data)
+		privateKey, err := serde.ParsePrivateKeyPEM(data)
 		if err != nil {
 			return err
 		}

--- a/pkg/inet256cmd/status.go
+++ b/pkg/inet256cmd/status.go
@@ -3,6 +3,7 @@ package inet256cmd
 import (
 	"fmt"
 
+	"github.com/brendoncarroll/go-p2p"
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/inet256/inet256/pkg/inet256srv"
 	"github.com/spf13/cobra"
@@ -22,7 +23,7 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 		var localAddr inet256.Addr
-		var transportAddrs []string
+		var transportAddrs []p2p.Addr
 		var peerStatuses []inet256srv.PeerStatus
 		eg := errgroup.Group{}
 		eg.Go(func() error {

--- a/pkg/inet256d/config.go
+++ b/pkg/inet256d/config.go
@@ -94,6 +94,9 @@ func MakeParams(configPath string, c Config) (*Params, error) {
 			sw = upnpswarm.WrapSwarm(sw)
 		}
 		secSw, err := quicswarm.New(sw, privateKey)
+		if err != nil {
+			return nil, err
+		}
 		swname = "quic+" + swname
 		swarms[swname] = secSw
 	}
@@ -101,7 +104,7 @@ func MakeParams(configPath string, c Config) (*Params, error) {
 	// peers
 	peers := inet256srv.NewPeerStore()
 	for _, pspec := range c.Peers {
-		addrs, err := parseAddrs(addrSchema, pspec.Addrs)
+		addrs, err := serde.ParseAddrs(addrSchema.ParseAddr, pspec.Addrs)
 		if err != nil {
 			return nil, err
 		}
@@ -215,16 +218,4 @@ func LoadConfig(p string) (*Config, error) {
 
 func strPtr(x string) *string {
 	return &x
-}
-
-func parseAddrs(schema multiswarm.AddrSchema, xs []string) ([]p2p.Addr, error) {
-	ys := make([]p2p.Addr, len(xs))
-	for i := range xs {
-		addr, err := schema.ParseAddr([]byte(xs[i]))
-		if err != nil {
-			return nil, err
-		}
-		ys[i] = addr
-	}
-	return ys, nil
 }

--- a/pkg/inet256d/config.go
+++ b/pkg/inet256d/config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/brendoncarroll/go-p2p"
+	"github.com/brendoncarroll/go-p2p/s/multiswarm"
 	"github.com/brendoncarroll/go-p2p/s/quicswarm"
 	"github.com/brendoncarroll/go-p2p/s/udpswarm"
 	"github.com/brendoncarroll/go-p2p/s/upnpswarm"
@@ -14,6 +15,7 @@ import (
 	"github.com/inet256/inet256/pkg/discovery/celldisco"
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/inet256/inet256/pkg/inet256srv"
+	"github.com/inet256/inet256/pkg/serde"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -21,8 +23,8 @@ import (
 const DefaultAPIAddr = "127.0.0.1:25600"
 
 type PeerSpec struct {
-	ID    p2p.PeerID `yaml:"id"`
-	Addrs []string   `yaml:"addrs"`
+	ID    inet256.Addr `yaml:"id"`
+	Addrs []string     `yaml:"addrs"`
 }
 
 type TransportSpec struct {
@@ -77,7 +79,7 @@ func MakeParams(configPath string, c Config) (*Params, error) {
 	if err != nil {
 		return nil, err
 	}
-	privateKey, err := inet256.ParsePrivateKeyPEM(keyPEMData)
+	privateKey, err := serde.ParsePrivateKeyPEM(keyPEMData)
 	if err != nil {
 		return nil, err
 	}
@@ -95,11 +97,16 @@ func MakeParams(configPath string, c Config) (*Params, error) {
 		swname = "quic+" + swname
 		swarms[swname] = secSw
 	}
+	addrSchema := multiswarm.NewSchemaFromSecureSwarms(swarms)
 	// peers
 	peers := inet256srv.NewPeerStore()
 	for _, pspec := range c.Peers {
+		addrs, err := parseAddrs(addrSchema, pspec.Addrs)
+		if err != nil {
+			return nil, err
+		}
 		peers.Add(pspec.ID)
-		peers.SetAddrs(pspec.ID, pspec.Addrs)
+		peers.SetAddrs(pspec.ID, addrs)
 	}
 	// networks
 	nspecs := []inet256.NetworkSpec{}
@@ -113,7 +120,7 @@ func MakeParams(configPath string, c Config) (*Params, error) {
 	// discovery
 	dscSrvs := []discovery.Service{}
 	for _, spec := range c.Discovery {
-		dscSrv, err := makeDiscoveryService(spec)
+		dscSrv, err := makeDiscoveryService(spec, addrSchema)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +129,7 @@ func MakeParams(configPath string, c Config) (*Params, error) {
 	// autopeering
 	apSrvs := []autopeering.Service{}
 	for _, spec := range c.AutoPeering {
-		apSrv, err := makeAutoPeeringService(spec)
+		apSrv, err := makeAutoPeeringService(spec, addrSchema)
 		if err != nil {
 			return nil, err
 		}
@@ -158,7 +165,7 @@ func makeTransport(spec TransportSpec, privKey p2p.PrivateKey) (p2p.Swarm, strin
 	}
 }
 
-func makeDiscoveryService(spec DiscoverySpec) (discovery.Service, error) {
+func makeDiscoveryService(spec DiscoverySpec, addrSchema multiswarm.AddrSchema) (discovery.Service, error) {
 	switch {
 	case spec.Cell != nil:
 		return celldisco.New(*spec.Cell)
@@ -167,7 +174,7 @@ func makeDiscoveryService(spec DiscoverySpec) (discovery.Service, error) {
 	}
 }
 
-func makeAutoPeeringService(spec AutoPeeringSpec) (autopeering.Service, error) {
+func makeAutoPeeringService(spec AutoPeeringSpec, addrSchema multiswarm.AddrSchema) (autopeering.Service, error) {
 	switch {
 	default:
 		return nil, errors.Errorf("empty autopeering spec")
@@ -208,4 +215,16 @@ func LoadConfig(p string) (*Config, error) {
 
 func strPtr(x string) *string {
 	return &x
+}
+
+func parseAddrs(schema multiswarm.AddrSchema, xs []string) ([]p2p.Addr, error) {
+	ys := make([]p2p.Addr, len(xs))
+	for i := range xs {
+		addr, err := schema.ParseAddr([]byte(xs[i]))
+		if err != nil {
+			return nil, err
+		}
+		ys[i] = addr
+	}
+	return ys, nil
 }

--- a/pkg/inet256d/daemon.go
+++ b/pkg/inet256d/daemon.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/brendoncarroll/go-p2p"
 	"github.com/inet256/inet256/pkg/autopeering"
 	"github.com/inet256/inet256/pkg/discovery"
 	"github.com/inet256/inet256/pkg/inet256"
@@ -42,7 +41,7 @@ func New(p Params) *Daemon {
 
 func (d *Daemon) Run(ctx context.Context) error {
 	nodeParams := d.params.MainNodeParams
-	localID := p2p.NewPeerID(nodeParams.PrivateKey.Public())
+	localID := inet256.NewAddr(nodeParams.PrivateKey.Public())
 
 	// discovery
 	dscSrvs := d.params.DiscoveryServices

--- a/pkg/inet256d/discovery.go
+++ b/pkg/inet256d/discovery.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/brendoncarroll/go-p2p"
+	"github.com/inet256/inet256/pkg/discovery"
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
-func (d *Daemon) runDiscoveryServices(ctx context.Context, localID p2p.PeerID, ds []p2p.DiscoveryService, localAddrs func() []string, ps []inet256.PeerStore) {
+func (d *Daemon) runDiscoveryServices(ctx context.Context, localID inet256.Addr, ds []discovery.Service, localAddrs func() []p2p.Addr, ps []inet256.PeerStore) {
 	eg := errgroup.Group{}
 	for i := range ds {
 		disc := ds[i]
@@ -22,7 +23,7 @@ func (d *Daemon) runDiscoveryServices(ctx context.Context, localID p2p.PeerID, d
 	eg.Wait()
 }
 
-func (d *Daemon) runDiscoveryService(ctx context.Context, localID p2p.PeerID, ds p2p.DiscoveryService, localAddrs func() []string, ps inet256.PeerStore) error {
+func (d *Daemon) runDiscoveryService(ctx context.Context, localID inet256.Addr, ds discovery.Service, localAddrs func() []p2p.Addr, ps inet256.PeerStore) error {
 	eg := errgroup.Group{}
 	// announce loop
 	eg.Go(func() error {
@@ -32,7 +33,7 @@ func (d *Daemon) runDiscoveryService(ctx context.Context, localID p2p.PeerID, ds
 		for {
 			addrs := localAddrs()
 			if err := ds.Announce(ctx, localID, addrs, ttl); err != nil {
-				logrus.Error("announce error:", err)
+				return err
 			}
 			// TODO: announce, and find, add each to the store
 			select {

--- a/pkg/inet256ipv6/mine.go
+++ b/pkg/inet256ipv6/mine.go
@@ -46,7 +46,7 @@ func MineAddr(ctx context.Context, r io.Reader, goal int) (inet256.Addr, p2p.Pri
 					if err != nil {
 						panic(err)
 					}
-					addr := p2p.NewPeerID(pubKey)
+					addr := inet256.NewAddr(pubKey)
 					if leading0s(addr[:]) > leading0s(addrs[i][:]) {
 						addrs[i] = addr
 						privKeys[i] = privKey

--- a/pkg/inet256ipv6/portal_config.go
+++ b/pkg/inet256ipv6/portal_config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brendoncarroll/go-p2p"
 	"github.com/inet256/inet256/pkg/inet256"
+	"github.com/inet256/inet256/pkg/serde"
 	"gopkg.in/yaml.v3"
 )
 
@@ -20,7 +21,7 @@ func (c *PortalConfig) GetPrivateKey() (p2p.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return inet256.ParsePrivateKey(data)
+	return serde.ParsePrivateKey(data)
 }
 
 func (c *PortalConfig) GetAllowFunc() AllowFunc {
@@ -39,7 +40,7 @@ func DefaultPortalConfig() PortalConfig {
 	if err != nil {
 		panic(err)
 	}
-	pkBytes, err := inet256.MarshalPrivateKey(privKey)
+	pkBytes, err := serde.MarshalPrivateKey(privKey)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/inet256p2p/asker.go
+++ b/pkg/inet256p2p/asker.go
@@ -81,11 +81,11 @@ func (a *asker) Ask(ctx context.Context, resp []byte, dst p2p.Addr, data p2p.IOV
 	vec := append(p2p.IOVec{m}, data...)
 
 	a.mu.Lock()
-	n := a.counts[dst.Key()]
-	a.counts[dst.Key()]++
+	n := a.counts[dst.String()]
+	a.counts[dst.String()]++
 	m.setIndex(n)
 	rkey := responseKey{
-		Addr: dst.Key(),
+		Addr: dst.String(),
 		N:    n,
 	}
 	ch := make(chan []byte, 1)
@@ -141,7 +141,7 @@ func (a *asker) handleMessage(ctx context.Context, msg p2p.Message) error {
 	case m.isAsk():
 		m = append([]byte{}, m...) // copy m
 		key := responseKey{
-			Addr: src.Key(),
+			Addr: src.String(),
 			N:    m.index(),
 		}
 		a.mu.Lock()

--- a/pkg/inet256p2p/swarm.go
+++ b/pkg/inet256p2p/swarm.go
@@ -4,22 +4,20 @@ import (
 	"context"
 
 	"github.com/brendoncarroll/go-p2p"
-	"github.com/brendoncarroll/go-p2p/s/peerswarm"
 	"github.com/inet256/inet256/client/go_client/inet256client"
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/inet256/inet256/pkg/inet256srv"
 )
 
 var _ p2p.SecureAskSwarm = &Swarm{}
-var _ peerswarm.AskSwarm = &Swarm{}
 
 type Swarm struct {
 	publicKey    p2p.PublicKey
-	inet256Swarm peerswarm.Swarm
+	inet256Swarm p2p.SecureSwarm
 	asker        *asker
 }
 
-func NewSwarm(endpoint string, privateKey p2p.PrivateKey) (peerswarm.AskSwarm, error) {
+func NewSwarm(endpoint string, privateKey p2p.PrivateKey) (p2p.SecureAskSwarm, error) {
 	client, err := inet256client.NewNode(endpoint, privateKey)
 	if err != nil {
 		return nil, err
@@ -37,20 +35,12 @@ func (s *Swarm) Tell(ctx context.Context, dst p2p.Addr, data p2p.IOVec) error {
 	return s.asker.Tell(ctx, dst, data)
 }
 
-func (s *Swarm) TellPeer(ctx context.Context, dst p2p.PeerID, data p2p.IOVec) error {
-	return s.asker.Tell(ctx, dst, data)
-}
-
 func (s *Swarm) Recv(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
 	return s.asker.Recv(ctx, src, dst, buf)
 }
 
 func (s *Swarm) Ask(ctx context.Context, resp []byte, dst p2p.Addr, data p2p.IOVec) (int, error) {
-	return s.asker.Ask(ctx, resp, dst, data)
-}
-
-func (s *Swarm) AskPeer(ctx context.Context, resp []byte, dst p2p.PeerID, data p2p.IOVec) (int, error) {
-	return s.asker.Ask(ctx, resp, dst, data)
+	return s.asker.Ask(ctx, resp, dst.(inet256.Addr), data)
 }
 
 func (s *Swarm) ServeAsk(ctx context.Context, fn p2p.AskHandler) error {
@@ -70,7 +60,7 @@ func (s *Swarm) LookupPublicKey(ctx context.Context, target p2p.Addr) (p2p.Publi
 }
 
 func (s *Swarm) MTU(ctx context.Context, target p2p.Addr) int {
-	return s.asker.MTU(ctx, target.(p2p.PeerID))
+	return s.asker.MTU(ctx, target.(inet256.Addr))
 }
 
 func (s *Swarm) MaxIncomingSize() int {
@@ -78,13 +68,10 @@ func (s *Swarm) MaxIncomingSize() int {
 }
 
 func (s *Swarm) Close() error {
-	return s.asker.Close()
+	s.asker.Close()
+	return s.inet256Swarm.Close()
 }
 
 func (s *Swarm) ParseAddr(data []byte) (p2p.Addr, error) {
-	id := p2p.PeerID{}
-	if err := id.UnmarshalText(data); err != nil {
-		return nil, err
-	}
-	return id, nil
+	return s.inet256Swarm.ParseAddr(data)
 }

--- a/pkg/inet256srv/adapter.go
+++ b/pkg/inet256srv/adapter.go
@@ -4,19 +4,16 @@ import (
 	"context"
 
 	"github.com/brendoncarroll/go-p2p"
-	"github.com/brendoncarroll/go-p2p/s/peerswarm"
 	"github.com/inet256/inet256/pkg/inet256"
 )
 
-var _ peerswarm.Swarm = &netAdapter{}
-
-// netAdapter converts an inet256.Network into a peerswarm.Swarm
+// netAdapter converts an inet256.Network into a p2p.Swarm
 type netAdapter struct {
 	publicKey p2p.PublicKey
 	network   Network
 }
 
-func SwarmFromNetwork(network Network, publicKey p2p.PublicKey) peerswarm.Swarm {
+func SwarmFromNetwork(network Network, publicKey p2p.PublicKey) p2p.SecureSwarm {
 	return &netAdapter{
 		publicKey: publicKey,
 		network:   network,
@@ -24,11 +21,7 @@ func SwarmFromNetwork(network Network, publicKey p2p.PublicKey) peerswarm.Swarm 
 }
 
 func (s *netAdapter) Tell(ctx context.Context, dst p2p.Addr, v p2p.IOVec) error {
-	return s.TellPeer(ctx, dst.(p2p.PeerID), v)
-}
-
-func (s *netAdapter) TellPeer(ctx context.Context, dst p2p.PeerID, v p2p.IOVec) error {
-	return s.network.Tell(ctx, dst, p2p.VecBytes(nil, v))
+	return s.network.Tell(ctx, dst.(inet256.Addr), p2p.VecBytes(nil, v))
 }
 
 func (s *netAdapter) Recv(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
@@ -43,7 +36,7 @@ func (s *netAdapter) Recv(ctx context.Context, src, dst *p2p.Addr, buf []byte) (
 }
 
 func (s *netAdapter) LocalAddrs() []p2p.Addr {
-	return []p2p.Addr{p2p.NewPeerID(s.publicKey)}
+	return []p2p.Addr{inet256.NewAddr(s.publicKey)}
 }
 
 func (s *netAdapter) PublicKey() p2p.PublicKey {
@@ -51,11 +44,11 @@ func (s *netAdapter) PublicKey() p2p.PublicKey {
 }
 
 func (s *netAdapter) LookupPublicKey(ctx context.Context, target p2p.Addr) (p2p.PublicKey, error) {
-	return s.network.LookupPublicKey(ctx, target.(p2p.PeerID))
+	return s.network.LookupPublicKey(ctx, target.(inet256.Addr))
 }
 
 func (s *netAdapter) MTU(ctx context.Context, target p2p.Addr) int {
-	return s.network.MTU(ctx, target.(p2p.PeerID))
+	return s.network.MTU(ctx, target.(inet256.Addr))
 }
 
 func (s *netAdapter) Close() error {
@@ -67,7 +60,7 @@ func (s *netAdapter) MaxIncomingSize() int {
 }
 
 func (s *netAdapter) ParseAddr(data []byte) (p2p.Addr, error) {
-	id := p2p.PeerID{}
+	id := inet256.Addr{}
 	if err := id.UnmarshalText(data); err != nil {
 		return nil, err
 	}
@@ -81,15 +74,15 @@ type BootstrapFunc = func(ctx context.Context) error
 var _ Network = &swarmAdapter{}
 
 type swarmAdapter struct {
-	peerswarm     PeerSwarm
+	swarm         p2p.SecureSwarm
 	findAddr      FindAddrFunc
 	bootstrapFunc BootstrapFunc
 	tells         *TellHub
 }
 
-func networkFromSwarm(x PeerSwarm, findAddr FindAddrFunc, bootstrapFunc BootstrapFunc) Network {
+func networkFromSwarm(x p2p.SecureSwarm, findAddr FindAddrFunc, bootstrapFunc BootstrapFunc) Network {
 	sa := &swarmAdapter{
-		peerswarm:     x,
+		swarm:         x,
 		findAddr:      findAddr,
 		bootstrapFunc: bootstrapFunc,
 		tells:         NewTellHub(),
@@ -99,13 +92,13 @@ func networkFromSwarm(x PeerSwarm, findAddr FindAddrFunc, bootstrapFunc Bootstra
 		buf := make([]byte, TransportMTU)
 		for {
 			var src, dst p2p.Addr
-			n, err := sa.peerswarm.Recv(ctx, &src, &dst, buf)
+			n, err := sa.swarm.Recv(ctx, &src, &dst, buf)
 			if err != nil {
 				return err
 			}
 			if err := sa.tells.Deliver(ctx, Message{
-				Src:     src.(p2p.PeerID),
-				Dst:     dst.(p2p.PeerID),
+				Src:     src.(inet256.Addr),
+				Dst:     dst.(inet256.Addr),
 				Payload: buf[:n],
 			}); err != nil {
 				return err
@@ -116,7 +109,7 @@ func networkFromSwarm(x PeerSwarm, findAddr FindAddrFunc, bootstrapFunc Bootstra
 }
 
 func (n *swarmAdapter) Tell(ctx context.Context, dst Addr, data []byte) error {
-	return n.peerswarm.TellPeer(ctx, dst, p2p.IOVec{data})
+	return n.swarm.Tell(ctx, dst, p2p.IOVec{data})
 }
 
 func (net *swarmAdapter) Recv(ctx context.Context, src, dst *Addr, buf []byte) (int, error) {
@@ -132,11 +125,11 @@ func (n *swarmAdapter) FindAddr(ctx context.Context, prefix []byte, nbits int) (
 }
 
 func (n *swarmAdapter) LookupPublicKey(ctx context.Context, target Addr) (p2p.PublicKey, error) {
-	return n.peerswarm.LookupPublicKey(ctx, target)
+	return n.swarm.LookupPublicKey(ctx, target)
 }
 
 func (n *swarmAdapter) LocalAddr() Addr {
-	return n.peerswarm.LocalAddrs()[0].(Addr)
+	return n.swarm.LocalAddrs()[0].(Addr)
 }
 
 func (n *swarmAdapter) Bootstrap(ctx context.Context) error {
@@ -144,9 +137,9 @@ func (n *swarmAdapter) Bootstrap(ctx context.Context) error {
 }
 
 func (n *swarmAdapter) Close() error {
-	return n.peerswarm.Close()
+	return n.swarm.Close()
 }
 
 func (n *swarmAdapter) MTU(ctx context.Context, target Addr) int {
-	return n.peerswarm.MTU(ctx, target)
+	return n.swarm.MTU(ctx, target)
 }

--- a/pkg/inet256srv/inet256_test.go
+++ b/pkg/inet256srv/inet256_test.go
@@ -50,3 +50,21 @@ func TestServerOneHop(t *testing.T) {
 		inet256test.TestSendRecvOne(t, nodes[i], main)
 	}
 }
+
+func TestServerCreateDelete(t *testing.T) {
+	ctx := context.Background()
+	s := inet256test.NewTestServer(t, inet256srv.OneHopFactory)
+
+	const N = 100
+	for i := 0; i < N; i++ {
+		pk := p2ptest.NewTestKey(t, i)
+		_, err := s.CreateNode(ctx, pk)
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < N; i++ {
+		pk := p2ptest.NewTestKey(t, i)
+		err := s.DeleteNode(pk)
+		require.NoError(t, err)
+	}
+}

--- a/pkg/inet256srv/network_impl.go
+++ b/pkg/inet256srv/network_impl.go
@@ -252,7 +252,7 @@ type loopbackNetwork struct {
 
 func newLoopbackNetwork(localKey p2p.PublicKey) Network {
 	ln := &loopbackNetwork{
-		localAddr: p2p.NewPeerID(localKey),
+		localAddr: inet256.NewAddr(localKey),
 		localKey:  localKey,
 		hub:       NewTellHub(),
 	}

--- a/pkg/inet256srv/onehop.go
+++ b/pkg/inet256srv/onehop.go
@@ -10,7 +10,7 @@ func OneHopFactory(params NetworkParams) Network {
 	findAddr := func(ctx context.Context, prefix []byte, nbits int) (Addr, error) {
 		for _, id := range params.Peers.ListPeers() {
 			if inet256.HasPrefix(id[:], prefix, nbits) {
-				return id, nil
+				return inet256.Addr(id), nil
 			}
 		}
 		return Addr{}, inet256.ErrNoAddrWithPrefix
@@ -18,5 +18,5 @@ func OneHopFactory(params NetworkParams) Network {
 	waitReady := func(ctx context.Context) error {
 		return nil
 	}
-	return networkFromSwarm(params.Swarm, findAddr, waitReady)
+	return networkFromSwarm(params.Swarm.(swarmWrapper).s, findAddr, waitReady)
 }

--- a/pkg/inet256srv/peerswarm.go
+++ b/pkg/inet256srv/peerswarm.go
@@ -1,12 +1,12 @@
 package inet256srv
 
 import (
+	"bytes"
 	"context"
 	"time"
 
 	"github.com/brendoncarroll/go-p2p"
 	"github.com/brendoncarroll/go-p2p/p/p2pmux"
-	"github.com/brendoncarroll/go-p2p/s/peerswarm"
 	"github.com/brendoncarroll/go-p2p/s/quicswarm"
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/sirupsen/logrus"
@@ -17,34 +17,30 @@ const (
 	channelData      = 127
 )
 
-type PeerSwarm = inet256.PeerSwarm
-
-var _ PeerSwarm = &peerSwarm{}
-
-// peerSwarm manages the mapping from transport addresses to peerIDs.
+// swarm manages the mapping from transport addresses p2p.Addr to inet256.Addrs.
 // a peer can be reachable at many addresses in the transport swarm.
 // Some of the addresses may not even be in the PeerStore
-type peerSwarm struct {
+type swarm struct {
 	peerStore PeerStore
 	inner     p2p.SecureSwarm
 
-	localID   p2p.PeerID
+	localID   inet256.Addr
 	mux       p2pmux.IntSecureMux
 	tm        *transportMonitor
 	dataSwarm p2p.SecureSwarm
 	meter     meter
 }
 
-func NewPeerSwarm(x p2p.SecureSwarm, peerStore PeerStore) peerswarm.Swarm {
-	return newPeerSwarm(x, peerStore)
+func NewSwarm(x p2p.SecureSwarm, peerStore PeerStore) inet256.Swarm {
+	return swarmWrapper{newSwarm(x, peerStore)}
 }
 
-func newPeerSwarm(x p2p.SecureSwarm, peerStore PeerStore) *peerSwarm {
+func newSwarm(x p2p.SecureSwarm, peerStore PeerStore) *swarm {
 	mux := p2pmux.NewVarintSecureMux(x)
-	return &peerSwarm{
+	return &swarm{
 		peerStore: peerStore,
 		inner:     x,
-		localID:   p2p.NewPeerID(x.PublicKey()),
+		localID:   inet256.NewAddr(x.PublicKey()),
 
 		mux:       mux,
 		tm:        newTransportMonitor(mux.Open(channelHeartbeat), peerStore, logrus.StandardLogger()),
@@ -52,20 +48,17 @@ func newPeerSwarm(x p2p.SecureSwarm, peerStore PeerStore) *peerSwarm {
 	}
 }
 
-func (s *peerSwarm) Tell(ctx context.Context, dst p2p.Addr, v p2p.IOVec) error {
-	return s.TellPeer(ctx, dst.(p2p.PeerID), v)
-}
-
-func (s *peerSwarm) TellPeer(ctx context.Context, dst p2p.PeerID, v p2p.IOVec) error {
-	addr, err := s.selectAddr(dst)
+func (s *swarm) Tell(ctx context.Context, dst p2p.Addr, v p2p.IOVec) error {
+	dst2 := dst.(inet256.Addr)
+	addr, err := s.selectAddr(dst2)
 	if err != nil {
 		return err
 	}
-	s.meter.Tx(dst, p2p.VecSize(v))
+	s.meter.Tx(dst2, p2p.VecSize(v))
 	return s.dataSwarm.Tell(ctx, addr, v)
 }
 
-func (s *peerSwarm) Recv(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
+func (s *swarm) Recv(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
 	for {
 		n, err := s.dataSwarm.Recv(ctx, src, dst, buf)
 		if err != nil {
@@ -76,9 +69,9 @@ func (s *peerSwarm) Recv(ctx context.Context, src, dst *p2p.Addr, buf []byte) (i
 			logrus.Error("could not lookup public key, dropping message: ", err)
 			continue
 		}
-		srcID := p2p.NewPeerID(srcKey)
+		srcID := inet256.NewAddr(srcKey)
 		s.tm.Mark(srcID, *src, time.Now())
-		s.meter.Rx(srcID, n)
+		s.meter.Rx(inet256.Addr(srcID), n)
 
 		*src = srcID
 		*dst = s.localID
@@ -86,23 +79,23 @@ func (s *peerSwarm) Recv(ctx context.Context, src, dst *p2p.Addr, buf []byte) (i
 	}
 }
 
-func (s *peerSwarm) PublicKey() p2p.PublicKey {
+func (s *swarm) PublicKey() p2p.PublicKey {
 	return s.inner.PublicKey()
 }
 
-func (s *peerSwarm) LocalAddrs() []p2p.Addr {
+func (s *swarm) LocalAddrs() []p2p.Addr {
 	return []p2p.Addr{s.localID}
 }
 
-func (s *peerSwarm) ParseAddr(data []byte) (p2p.Addr, error) {
-	id := p2p.PeerID{}
+func (s *swarm) ParseAddr(data []byte) (p2p.Addr, error) {
+	id := inet256.Addr{}
 	if err := id.UnmarshalText(data); err != nil {
 		return nil, err
 	}
 	return id, nil
 }
 
-func (s *peerSwarm) Close() error {
+func (s *swarm) Close() error {
 	if err := s.tm.Close(); err != nil {
 		logrus.Error(err)
 	}
@@ -112,8 +105,8 @@ func (s *peerSwarm) Close() error {
 	return s.inner.Close()
 }
 
-func (s *peerSwarm) MTU(ctx context.Context, target p2p.Addr) int {
-	addr, err := s.selectAddr(target.(p2p.PeerID))
+func (s *swarm) MTU(ctx context.Context, target p2p.Addr) int {
+	addr, err := s.selectAddr(target.(inet256.Addr))
 	if err != nil {
 		// TODO: figure out what to do here
 		return 512
@@ -121,101 +114,136 @@ func (s *peerSwarm) MTU(ctx context.Context, target p2p.Addr) int {
 	return s.dataSwarm.MTU(ctx, addr)
 }
 
-func (s *peerSwarm) MaxIncomingSize() int {
+func (s *swarm) MaxIncomingSize() int {
 	return s.inner.MaxIncomingSize()
 }
 
-func (s *peerSwarm) LookupPublicKey(ctx context.Context, target p2p.Addr) (p2p.PublicKey, error) {
-	if !s.peerStore.Contains(target.(p2p.PeerID)) {
+func (s *swarm) LookupPublicKey(ctx context.Context, target p2p.Addr) (p2p.PublicKey, error) {
+	if !s.peerStore.Contains(target.(inet256.Addr)) {
 		return nil, p2p.ErrPublicKeyNotFound
 	}
-	addr, err := s.selectAddr(target.(p2p.PeerID))
+	addr, err := s.selectAddr(target.(inet256.Addr))
 	if err != nil {
 		return nil, err
 	}
 	return s.dataSwarm.LookupPublicKey(ctx, addr)
 }
 
-func (s *peerSwarm) selectAddr(x p2p.PeerID) (p2p.Addr, error) {
+func (s *swarm) selectAddr(x inet256.Addr) (p2p.Addr, error) {
 	return s.tm.PickAddr(x)
 }
 
-func (s *peerSwarm) LastSeen(id p2p.PeerID) map[string]time.Time {
+func (s *swarm) LastSeen(id inet256.Addr) map[string]time.Time {
 	return s.tm.LastSeen(id)
 }
 
-func (s *peerSwarm) GetTx(id p2p.PeerID) uint64 {
+func (s *swarm) GetTx(id inet256.Addr) uint64 {
 	return s.meter.Tx(id, 0)
 }
 
-func (s *peerSwarm) GetRx(id p2p.PeerID) uint64 {
+func (s *swarm) GetRx(id inet256.Addr) uint64 {
 	return s.meter.Rx(id, 0)
 }
 
-type peerSwarmWrapper struct {
-	p2p.SecureSwarm
+// swarmWrapper converts a p2p.SecureSwarm to an inet256.Swarm
+type swarmWrapper struct {
+	s p2p.SecureSwarm
 }
 
-func castPeerSwarm(x p2p.SecureSwarm) peerSwarmWrapper {
-	return peerSwarmWrapper{x}
+func (s swarmWrapper) Tell(ctx context.Context, dst Addr, m p2p.IOVec) error {
+	return s.s.Tell(ctx, dst, m)
 }
 
-func (s peerSwarmWrapper) TellPeer(ctx context.Context, id p2p.PeerID, v p2p.IOVec) error {
-	return s.SecureSwarm.Tell(ctx, id, v)
+func (s swarmWrapper) Recv(ctx context.Context, src, dst *Addr, buf []byte) (int, error) {
+	var src2, dst2 p2p.Addr
+	n, err := s.s.Recv(ctx, &src2, &dst2, buf)
+	if err != nil {
+		return n, err
+	}
+	*src = src2.(Addr)
+	*dst = dst2.(Addr)
+	return n, err
 }
 
-type quic2PeerSwarm struct {
-	*quicswarm.Swarm
+func (s swarmWrapper) LookupPublicKey(ctx context.Context, target Addr) (inet256.PublicKey, error) {
+	return s.s.LookupPublicKey(ctx, target)
 }
 
-func newSecureNetwork(privateKey p2p.PrivateKey, x Network) Network {
-	insecSw := SwarmFromNetwork(x, privateKey.Public())
-	quicSw, err := quicswarm.New(insecSw, privateKey)
+func (s swarmWrapper) LocalAddr() Addr {
+	return s.s.LocalAddrs()[0].(Addr)
+}
+
+func (s swarmWrapper) Close() error {
+	return s.s.Close()
+}
+
+func newSecureNetwork(privateKey inet256.PrivateKey, x Network) Network {
+	insecSwarm := SwarmFromNetwork(x, privateKey.Public())
+	quicSw, err := quicswarm.New(insecSwarm, privateKey)
 	if err != nil {
 		panic(err)
 	}
-	secnet := networkFromSwarm(quic2PeerSwarm{quicSw}, x.FindAddr, x.Bootstrap)
+	secnet := networkFromSwarm(quic2Swarm{quicSw}, x.FindAddr, x.Bootstrap)
 	return secnet
 }
 
-func (s quic2PeerSwarm) Recv(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
-	n, err := s.Swarm.Recv(ctx, src, dst, buf)
-	if err != nil {
-		return 0, err
+// quic2Swarm turns quicswarm.Addr into inet256.Addr
+type quic2Swarm struct {
+	*quicswarm.Swarm
+}
+
+func (s quic2Swarm) Recv(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
+	for {
+		n, err := s.Swarm.Recv(ctx, src, dst, buf)
+		if err != nil {
+			return 0, err
+		}
+		// This is where the actual check for who can send as what address happens
+		srcID := p2p.ExtractPeerID(*src)
+		srcAddr := (*src).(quicswarm.Addr).Addr.(inet256.Addr)
+		if !bytes.Equal(srcID[:], srcAddr[:]) {
+			logrus.Warnf("incorrect id=%v for address=%v", srcID, srcAddr)
+			continue
+		}
+		*src = srcAddr
+		*dst = (*dst).(quicswarm.Addr).Addr
+		return n, nil
 	}
-	*src = (*src).(quicswarm.Addr).ID
-	*dst = (*dst).(quicswarm.Addr).ID
-	return n, nil
 }
 
-func (s quic2PeerSwarm) Tell(ctx context.Context, id p2p.Addr, data p2p.IOVec) error {
-	return s.TellPeer(ctx, id.(p2p.PeerID), data)
+func (s quic2Swarm) Tell(ctx context.Context, x p2p.Addr, data p2p.IOVec) error {
+	dst := s.makeAddr(x.(inet256.Addr))
+	return s.Swarm.Tell(ctx, dst, data)
 }
 
-func (s quic2PeerSwarm) TellPeer(ctx context.Context, id p2p.PeerID, data p2p.IOVec) error {
-	return s.Swarm.Tell(ctx, quicswarm.Addr{ID: id, Addr: id}, data)
+func (s quic2Swarm) LocalAddr() p2p.Addr {
+	return s.Swarm.LocalAddrs()[0].(quicswarm.Addr).Addr
 }
 
-func (s quic2PeerSwarm) LocalAddrs() (ys []p2p.Addr) {
+func (s quic2Swarm) LocalAddrs() (ys []p2p.Addr) {
 	for _, x := range s.Swarm.LocalAddrs() {
-		ys = append(ys, x.(quicswarm.Addr).ID)
+		ys = append(ys, x.(quicswarm.Addr).Addr)
 	}
 	return ys
 }
 
-func (s quic2PeerSwarm) LookupPublicKey(ctx context.Context, target p2p.Addr) (p2p.PublicKey, error) {
-	id := target.(p2p.PeerID)
-	return s.Swarm.LookupPublicKey(ctx, quicswarm.Addr{ID: id, Addr: id})
+func (s quic2Swarm) LookupPublicKey(ctx context.Context, target p2p.Addr) (p2p.PublicKey, error) {
+	x := s.makeAddr(target.(inet256.Addr))
+	return s.Swarm.LookupPublicKey(ctx, x)
 }
 
-func (s quic2PeerSwarm) LocalID() p2p.PeerID {
-	return s.Swarm.LocalAddrs()[0].(quicswarm.Addr).ID
-}
-
-func (s quic2PeerSwarm) ParseAddr(x []byte) (p2p.Addr, error) {
-	id := p2p.PeerID{}
+func (s quic2Swarm) ParseAddr(x []byte) (p2p.Addr, error) {
+	id := inet256.Addr{}
 	if err := id.UnmarshalText(x); err != nil {
 		return nil, err
 	}
 	return id, nil
+}
+
+func (s quic2Swarm) makeAddr(addr inet256.Addr) quicswarm.Addr {
+	id := p2p.PeerID(addr)
+	return quicswarm.Addr{
+		ID:   id,
+		Addr: addr,
+	}
 }

--- a/pkg/inet256srv/peerswarm_test.go
+++ b/pkg/inet256srv/peerswarm_test.go
@@ -14,7 +14,7 @@ func TestPeerSwarm(t *testing.T) {
 		r := memswarm.NewRealm()
 		for i := range swarms {
 			pk := p2ptest.NewTestKey(t, i)
-			swarms[i] = newPeerSwarm(r.NewSwarmWithKey(pk), NewPeerStore())
+			swarms[i] = newSwarm(r.NewSwarmWithKey(pk), NewPeerStore())
 		}
 	})
 }

--- a/pkg/serde/serde.go
+++ b/pkg/serde/serde.go
@@ -1,0 +1,74 @@
+package serde
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+
+	"github.com/brendoncarroll/go-p2p"
+	"github.com/pkg/errors"
+)
+
+func MarshalPrivateKey(privKey p2p.PrivateKey) ([]byte, error) {
+	return x509.MarshalPKCS8PrivateKey(privKey)
+}
+
+func ParsePrivateKey(data []byte) (p2p.PrivateKey, error) {
+	privKey, err := x509.ParsePKCS8PrivateKey(data)
+	if err != nil {
+		return nil, err
+	}
+	privKey2, ok := privKey.(p2p.PrivateKey)
+	if !ok {
+		return nil, errors.Errorf("unsupported private key type")
+	}
+	return privKey2, nil
+}
+
+func MarshalPrivateKeyPEM(privateKey p2p.PrivateKey) ([]byte, error) {
+	data, err := MarshalPrivateKey(privateKey)
+	if err != nil {
+		return nil, err
+	}
+	privKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: data,
+	})
+	return privKeyPEM, nil
+}
+
+func ParsePrivateKeyPEM(data []byte) (p2p.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("key file does not contain PEM")
+	}
+	if block.Type != "PRIVATE KEY" {
+		return nil, errors.New("wrong type for PEM block")
+	}
+	return ParsePrivateKey(block.Bytes)
+}
+
+func MarshalAddrs(xs []p2p.Addr) []string {
+	ys := make([]string, len(xs))
+	for i := range xs {
+		data, err := xs[i].MarshalText()
+		if err != nil {
+			panic(err)
+		}
+		ys[i] = string(data)
+	}
+	return ys
+}
+
+type AddrParserFunc = func([]byte) (p2p.Addr, error)
+
+func ParseAddrs(parser AddrParserFunc, xs []string) ([]p2p.Addr, error) {
+	ys := make([]p2p.Addr, len(xs))
+	for i := range xs {
+		addr, err := parser([]byte(xs[i]))
+		if err != nil {
+			return nil, err
+		}
+		ys[i] = addr
+	}
+	return ys, nil
+}


### PR DESCRIPTION
Defines inet256.Addr to be a separate type from p2p.PeerID, rather than an alias.  Removes references to p2p.DiscoveryService and peerswarm.