### PR TITLE
Receive API change

### DIFF
--- a/client/go_client/inet256client/node.go
+++ b/client/go_client/inet256client/node.go
@@ -80,6 +80,10 @@ func (n *node) LocalAddr() inet256.Addr {
 	return n.localAddr
 }
 
+func (n *node) PublicKey() inet256.PublicKey {
+	return n.privKey.Public()
+}
+
 func (n *node) FindAddr(ctx context.Context, prefix []byte, nbits int) (inet256.Addr, error) {
 	return n.getClient().FindAddr(ctx, prefix, nbits)
 }

--- a/client/go_client/inet256client/util.go
+++ b/client/go_client/inet256client/util.go
@@ -12,6 +12,7 @@ import (
 )
 
 // NewPacketConn wraps the Network n in an adapter exposing the net.PacketConn interface instead.
+// inet256.Nodes are also inet256.Networks.  One interface is a superset of the other.
 func NewPacketConn(n inet256.Network) net.PacketConn {
 	return inet256.NewPacketConn(n)
 }
@@ -23,5 +24,5 @@ func NewTestService(t testing.TB) inet256.Service {
 
 // NewSwarm creates a p2p.SecureSwarm from an inet256.Network.
 func NewSwarm(n inet256.Network, pubKey p2p.PublicKey) p2p.SecureSwarm {
-	return inet256srv.SwarmFromNetwork(n, pubKey)
+	return inet256srv.SwarmFromNetwork(n)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/inet256/inet256
 go 1.15
 
 require (
-	github.com/brendoncarroll/go-p2p v0.0.0-20210919135625-d98b36c3d8ad
+	github.com/brendoncarroll/go-p2p v0.0.0-20211002140027-077fa7f0ec76
 	github.com/golang/protobuf v1.5.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
-github.com/brendoncarroll/go-p2p v0.0.0-20210919135625-d98b36c3d8ad h1:jlxLTSYclUpDocUu8Sl+CJ3Hcc3PxlfHnvL3+K8tRr8=
-github.com/brendoncarroll/go-p2p v0.0.0-20210919135625-d98b36c3d8ad/go.mod h1:IYW1gZ9twSWJrkAil9jLMtHnVlAJ0wVc9Y5WpNlv9Oc=
+github.com/brendoncarroll/go-p2p v0.0.0-20211002140027-077fa7f0ec76 h1:5uQWc2AmchSawYRFoYV9/atNNQ3oHhkMvGvYgxEvuy0=
+github.com/brendoncarroll/go-p2p v0.0.0-20211002140027-077fa7f0ec76/go.mod h1:IYW1gZ9twSWJrkAil9jLMtHnVlAJ0wVc9Y5WpNlv9Oc=
 github.com/brendoncarroll/go-state v0.0.0-20210627233638-99c825eb7040 h1:I46IjykpWXCBYWVWGX8wqX7YCGWoAEY48+aR3p9tpak=
 github.com/brendoncarroll/go-state v0.0.0-20210627233638-99c825eb7040/go.mod h1:EQKdXJyc93dh3yN1wRYdKjAZk+MutF5DFwoW+Vqe5U0=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=

--- a/pkg/inet256/addr.go
+++ b/pkg/inet256/addr.go
@@ -15,6 +15,9 @@ type (
 // It uniquely identifies a Node.
 type Addr [32]byte
 
+// ID is an alias for Addr
+type ID = Addr
+
 // NewAddr creates a new Addr from a PublicKey
 func NewAddr(pubKey PublicKey) Addr {
 	addr := Addr{}

--- a/pkg/inet256srv/link_monitor.go
+++ b/pkg/inet256srv/link_monitor.go
@@ -45,19 +45,17 @@ func newLinkMonitor(x p2p.SecureSwarm, peerStore PeerStore, log *Logger) *linkMo
 }
 
 func (lm *linkMonitor) recvLoop(ctx context.Context) error {
-	buf := make([]byte, lm.x.MaxIncomingSize())
+	var msg p2p.Message
 	for {
-		var src, dst p2p.Addr
-		_, err := lm.x.Receive(ctx, &src, &dst, buf)
-		if err != nil {
+		if err := p2p.Receive(ctx, lm.x, &msg); err != nil {
 			return err
 		}
-		pubKey, err := lm.x.LookupPublicKey(ctx, src)
+		pubKey, err := lm.x.LookupPublicKey(ctx, msg.Src)
 		if err != nil {
 			lm.log.Error("in linkMonitor.recvLoop: ", err)
 			continue
 		}
-		lm.Mark(inet256.NewAddr(pubKey), src, time.Now())
+		lm.Mark(inet256.NewAddr(pubKey), msg.Src, time.Now())
 	}
 }
 

--- a/pkg/inet256srv/network_impl.go
+++ b/pkg/inet256srv/network_impl.go
@@ -80,6 +80,10 @@ func (mn *multiNetwork) MTU(ctx context.Context, target Addr) int {
 	return network.MTU(ctx, target)
 }
 
+func (mn *multiNetwork) PublicKey() inet256.PublicKey {
+	return mn.networks[0].PublicKey()
+}
+
 func (mn *multiNetwork) LocalAddr() Addr {
 	return mn.networks[0].LocalAddr()
 }
@@ -202,6 +206,10 @@ func (n chainNetwork) LocalAddr() Addr {
 	return n.networks[0].LocalAddr()
 }
 
+func (n chainNetwork) PublicKey() inet256.PublicKey {
+	return n.networks[0].PublicKey()
+}
+
 func (n chainNetwork) Close() (retErr error) {
 	var el netutil.ErrList
 	el.Do(n.selector.Close)
@@ -272,6 +280,10 @@ func (n *loopbackNetwork) FindAddr(ctx context.Context, prefix []byte, nbits int
 
 func (n *loopbackNetwork) LocalAddr() Addr {
 	return n.localAddr
+}
+
+func (n *loopbackNetwork) PublicKey() inet256.PublicKey {
+	return n.localKey
 }
 
 func (n *loopbackNetwork) Close() error {

--- a/pkg/inet256srv/node.go
+++ b/pkg/inet256srv/node.go
@@ -93,8 +93,12 @@ func (n *node) LocalAddr() Addr {
 	return inet256.NewAddr(n.params.PrivateKey.Public())
 }
 
-func (n *node) LookupPublicKey(ctx context.Context, target Addr) (p2p.PublicKey, error) {
+func (n *node) LookupPublicKey(ctx context.Context, target Addr) (inet256.PublicKey, error) {
 	return n.network.LookupPublicKey(ctx, target)
+}
+
+func (n *node) PublicKey() inet256.PublicKey {
+	return n.params.PrivateKey.Public()
 }
 
 func (n *node) MTU(ctx context.Context, target Addr) int {
@@ -122,5 +126,5 @@ func (n *node) Close() (retErr error) {
 	el.Do(n.network.Close)
 	el.Do(n.basePeerSwarm.Close)
 	el.Do(n.transportSwarm.Close)
-	return el.Err()	
+	return el.Err()
 }

--- a/pkg/inet256srv/swarm_test.go
+++ b/pkg/inet256srv/swarm_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brendoncarroll/go-p2p/s/swarmtest"
 )
 
-func TestPeerSwarm(t *testing.T) {
+func TestSwarm(t *testing.T) {
 	swarmtest.TestSecureSwarm(t, func(t testing.TB, swarms []p2p.SecureSwarm) {
 		r := memswarm.NewRealm()
 		for i := range swarms {


### PR DESCRIPTION
Upgrades go-p2p, which has a new API for Receive.  The changes propagate into the `inet256.Swarm` interface.  The Network and Node Receive methods are unchanged.