### PR TITLE
Refactor `inet256test.TestService`, tighten up `inet256` interfaces

### DIFF
--- a/client/go_client/inet256client/client.go
+++ b/client/go_client/inet256client/client.go
@@ -62,7 +62,7 @@ func (c *client) CreateNode(ctx context.Context, privKey p2p.PrivateKey) (inet25
 	return n, nil
 }
 
-func (c *client) DeleteNode(privKey p2p.PrivateKey) error {
+func (c *client) DeleteNode(ctx context.Context, privKey p2p.PrivateKey) error {
 	panic("not implemented")
 }
 

--- a/client/go_client/inet256client/clientserver_test.go
+++ b/client/go_client/inet256client/clientserver_test.go
@@ -4,10 +4,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/brendoncarroll/go-p2p"
 	"github.com/brendoncarroll/go-p2p/p2ptest"
-	"github.com/brendoncarroll/go-p2p/s/memswarm"
-	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/inet256/inet256/pkg/inet256grpc"
 	"github.com/inet256/inet256/pkg/inet256srv"
 	"github.com/inet256/inet256/pkg/inet256test"
@@ -16,18 +13,8 @@ import (
 )
 
 func TestDial(t *testing.T) {
-	mr := memswarm.NewRealm()
 	privateKey := p2ptest.NewTestKey(t, 0)
-	serv := inet256srv.NewServer(inet256srv.Params{
-		PrivateKey: privateKey,
-		Networks: map[inet256srv.NetworkCode]inet256.NetworkFactory{
-			{}: inet256srv.OneHopFactory,
-		},
-		Peers: inet256srv.NewPeerStore(),
-		Swarms: map[string]p2p.Swarm{
-			"virtual": mr.NewSwarmWithKey(privateKey),
-		},
-	})
+	serv := inet256srv.NewTestServer(t, inet256srv.OneHopFactory)
 	s := inet256grpc.NewServer(serv)
 	gs := grpc.NewServer()
 	inet256grpc.RegisterINET256Server(gs, s)

--- a/client/go_client/inet256client/node.go
+++ b/client/go_client/inet256client/node.go
@@ -127,10 +127,7 @@ func (n *node) connect(ctx context.Context) (inet256grpc.INET256_ConnectClient, 
 	if err != nil {
 		return nil, err
 	}
-	privKeyBytes, err := serde.MarshalPrivateKey(n.privKey)
-	if err != nil {
-		panic(err)
-	}
+	privKeyBytes := serde.MarshalPrivateKey(n.privKey)
 	if err := cc.Send(&inet256grpc.ConnectMsg{
 		ConnectInit: &inet256grpc.ConnectInit{
 			PrivateKey: privKeyBytes,

--- a/client/go_client/inet256client/util.go
+++ b/client/go_client/inet256client/util.go
@@ -8,21 +8,19 @@ import (
 	"github.com/inet256/inet256/networks/beaconnet"
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/inet256/inet256/pkg/inet256srv"
-	"github.com/inet256/inet256/pkg/inet256test"
 )
 
-// NewPacketConn wraps the Network n in an adapter exposing the net.PacketConn interface instead.
-// inet256.Nodes are also inet256.Networks.  One interface is a superset of the other.
-func NewPacketConn(n inet256.Network) net.PacketConn {
+// NewPacketConn wraps the Node n in an adapter exposing the net.PacketConn interface instead.
+func NewPacketConn(n inet256.Node) net.PacketConn {
 	return inet256.NewPacketConn(n)
 }
 
 // NewTestService can be used to spawn an inet256 service without any peering for use in tests
 func NewTestService(t testing.TB) inet256.Service {
-	return inet256test.NewTestServer(t, beaconnet.Factory)
+	return inet256srv.NewTestServer(t, beaconnet.Factory)
 }
 
-// NewSwarm creates a p2p.SecureSwarm from an inet256.Network.
-func NewSwarm(n inet256.Network, pubKey p2p.PublicKey) p2p.SecureSwarm {
-	return inet256srv.SwarmFromNetwork(n)
+// NewSwarm creates a p2p.SecureSwarm from an inet256.Node.
+func NewSwarm(n inet256.Node, pubKey p2p.PublicKey) p2p.SecureSwarm {
+	return inet256srv.SwarmFromNode(n)
 }

--- a/networks/beaconnet/network_test.go
+++ b/networks/beaconnet/network_test.go
@@ -3,6 +3,8 @@ package beaconnet
 import (
 	"testing"
 
+	"github.com/inet256/inet256/pkg/inet256"
+	"github.com/inet256/inet256/pkg/inet256srv"
 	"github.com/inet256/inet256/pkg/inet256test"
 )
 
@@ -11,5 +13,7 @@ func TestNetwork(t *testing.T) {
 }
 
 func TestServer(t *testing.T) {
-	inet256test.TestServer(t, Factory)
+	inet256test.TestService(t, func(t *testing.T, xs []inet256.Service) {
+		inet256srv.NewTestServers(t, Factory, xs)
+	})
 }

--- a/networks/floodnet/floodnet_test.go
+++ b/networks/floodnet/floodnet_test.go
@@ -3,6 +3,8 @@ package floodnet
 import (
 	"testing"
 
+	"github.com/inet256/inet256/pkg/inet256"
+	"github.com/inet256/inet256/pkg/inet256srv"
 	"github.com/inet256/inet256/pkg/inet256test"
 )
 
@@ -11,5 +13,7 @@ func TestNetwork(t *testing.T) {
 }
 
 func TestServer(t *testing.T) {
-	inet256test.TestServer(t, Factory)
+	inet256test.TestService(t, func(t *testing.T, xs []inet256.Service) {
+		inet256srv.NewTestServers(t, Factory, xs)
+	})
 }

--- a/pkg/inet256/errors.go
+++ b/pkg/inet256/errors.go
@@ -11,7 +11,6 @@ import (
 var (
 	ErrPublicKeyNotFound = p2p.ErrPublicKeyNotFound
 	ErrNoAddrWithPrefix  = errors.New("no address with prefix")
-	ErrWouldBlock        = errors.New("call to Recv would block")
 	ErrClosed            = net.ErrClosed
 )
 
@@ -34,8 +33,4 @@ type ErrAddrUnreachable struct {
 
 func (e ErrAddrUnreachable) Error() string {
 	return fmt.Sprintf("address is unreachable: %v", e.Addr)
-}
-
-func IsErrWouldBlock(err error) bool {
-	return err == ErrWouldBlock
 }

--- a/pkg/inet256/packetconn.go
+++ b/pkg/inet256/packetconn.go
@@ -10,13 +10,14 @@ import (
 )
 
 type packetConn struct {
-	n Network
+	n Node
 
 	mu                          sync.RWMutex
 	readDeadline, writeDeadline *time.Time
 }
 
-func NewPacketConn(n Network) net.PacketConn {
+// NewPacketConn wraps a node with the net.PacketConn interface
+func NewPacketConn(n Node) net.PacketConn {
 	return &packetConn{n: n}
 }
 

--- a/pkg/inet256/service.go
+++ b/pkg/inet256/service.go
@@ -33,16 +33,29 @@ type ReceiveFunc = func(Message)
 //
 // This interface is compatible with the INET256 specification.
 type Node interface {
+	// Tell sends a message containing data to the node at addr.
+	// The message will be delivered at most once.
 	Tell(ctx context.Context, addr Addr, data []byte) error
+	// Receive calls fn with a message sent to this node.
+	// The message fields, and payload must not be accessed outside fn.
 	Receive(ctx context.Context, fn ReceiveFunc) error
 
+	// MTU finds the maximum message size that can be sent to addr.
+	// If the context expires, a reasonable default (normally a significant underestimate) will be returned.
 	MTU(ctx context.Context, addr Addr) int
+	// LookupPublicKey attempts to find the public key corresponding to addr.
+	// If it can't find it, ErrPublicKeyNotFound is returned.
 	LookupPublicKey(ctx context.Context, addr Addr) (PublicKey, error)
+	// FindAddr looks for an address with nbits leading bits in common with prefix.
 	FindAddr(ctx context.Context, prefix []byte, nbits int) (Addr, error)
 
+	// LocalAddr returns this Node's address
 	LocalAddr() Addr
+	// PublicKey returns this Node's public key
 	PublicKey() PublicKey
 
+	// Close indicates no more messages should be sent or received from this node
+	// and releases any resources allocated for this node.
 	Close() error
 }
 
@@ -59,7 +72,7 @@ type Service interface {
 	MTU(ctx context.Context, addr Addr) int
 }
 
-// Receive is a utility method for copying a message from the Node n into msg
+// Receive is a utility function for copying a message from the Node n into msg
 func Receive(ctx context.Context, n Node, msg *Message) error {
 	return n.Receive(ctx, func(m2 Message) {
 		msg.Src = m2.Src

--- a/pkg/inet256/service.go
+++ b/pkg/inet256/service.go
@@ -6,12 +6,50 @@ import (
 	"github.com/brendoncarroll/go-p2p"
 )
 
-type Node interface {
-	Network
+const (
+	// MinMTU is the minimum MTU a network can provide to any address.
+	// Applications should be designed to operate correctly if they can only send messages up to this size.
+	MinMTU = 1 << 15
+	// MaxMTU is the size of largest message that a network will ever receive from any address.
+	// Applications should be prepared to receieve this much data at a time or they may encounter io.ErrShortBuffer
+	MaxMTU = 1 << 16
+)
 
-	ListOneHop() []Addr
+// Message is the essential information carried by Tell and Receive
+// provided as a struct for use in queues or other APIs
+type Message struct {
+	Src     Addr
+	Dst     Addr
+	Payload []byte
 }
 
+// ReceiveFunc is passed as a callback to Node.Receive
+type ReceiveFunc = func(Message)
+
+// Node is a single host in an INET256 network.
+// Nodes send and receive messages to and from other nodes in the network.
+// Nodes are usually created and managed by a Service.
+// Nodes have an single ID or address corresponding to their public key.
+//
+// This interface is compatible with the INET256 specification.
+type Node interface {
+	Tell(ctx context.Context, addr Addr, data []byte) error
+	Receive(ctx context.Context, fn ReceiveFunc) error
+
+	MTU(ctx context.Context, addr Addr) int
+	LookupPublicKey(ctx context.Context, addr Addr) (PublicKey, error)
+	FindAddr(ctx context.Context, prefix []byte, nbits int) (Addr, error)
+
+	LocalAddr() Addr
+	PublicKey() PublicKey
+
+	Close() error
+}
+
+// Service is the top level INET256 object.
+// It manages a set of nodes which can be created and deleted.
+//
+// This interface is compatible with the INET256 specification.
 type Service interface {
 	CreateNode(ctx context.Context, privKey p2p.PrivateKey) (Node, error)
 	DeleteNode(privKey p2p.PrivateKey) error
@@ -19,4 +57,13 @@ type Service interface {
 	LookupPublicKey(ctx context.Context, addr Addr) (p2p.PublicKey, error)
 	FindAddr(ctx context.Context, prefix []byte, nbits int) (Addr, error)
 	MTU(ctx context.Context, addr Addr) int
+}
+
+// Receive is a utility method for copying a message from the Node n into msg
+func Receive(ctx context.Context, n Node, msg *Message) error {
+	return n.Receive(ctx, func(m2 Message) {
+		msg.Src = m2.Src
+		msg.Dst = m2.Dst
+		msg.Payload = append(msg.Payload[:0], m2.Payload...)
+	})
 }

--- a/pkg/inet256/service.go
+++ b/pkg/inet256/service.go
@@ -52,7 +52,7 @@ type Node interface {
 // This interface is compatible with the INET256 specification.
 type Service interface {
 	CreateNode(ctx context.Context, privKey p2p.PrivateKey) (Node, error)
-	DeleteNode(privKey p2p.PrivateKey) error
+	DeleteNode(ctx context.Context, privKey p2p.PrivateKey) error
 
 	LookupPublicKey(ctx context.Context, addr Addr) (p2p.PublicKey, error)
 	FindAddr(ctx context.Context, prefix []byte, nbits int) (Addr, error)

--- a/pkg/inet256cmd/ip6.go
+++ b/pkg/inet256cmd/ip6.go
@@ -47,7 +47,7 @@ var portalCmd = &cobra.Command{
 		}
 		return inet256ipv6.RunPortal(ctx, inet256ipv6.PortalParams{
 			AllowFunc: config.GetAllowFunc(),
-			Network:   n,
+			Node:      n,
 			Logger:    logrus.New(),
 		})
 	},

--- a/pkg/inet256cmd/root.go
+++ b/pkg/inet256cmd/root.go
@@ -27,7 +27,7 @@ func newClient() (inet256srv.Service, error) {
 	return inet256client.NewExtendedClient(defaultAPIAddr)
 }
 
-func newNode(ctx context.Context, privateKey p2p.PrivateKey) (inet256.Network, error) {
+func newNode(ctx context.Context, privateKey p2p.PrivateKey) (inet256.Node, error) {
 	c, err := newClient()
 	if err != nil {
 		return nil, err

--- a/pkg/inet256grpc/server.go
+++ b/pkg/inet256grpc/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"io"
-	sync "sync"
 	"time"
 
 	"github.com/brendoncarroll/go-p2p"
@@ -23,19 +22,13 @@ var _ INET256Server = &Server{}
 type Server struct {
 	s inet256.Service
 
-	mu     sync.Mutex
-	nodes  map[inet256.Addr]inet256.Node
-	counts map[inet256.Addr]int
-
 	UnimplementedINET256Server
 	UnimplementedAdminServer
 }
 
 func NewServer(s inet256.Service) *Server {
 	return &Server{
-		s:      s,
-		nodes:  make(map[inet256.Addr]inet256.Node),
-		counts: make(map[inet256.Addr]int),
+		s: s,
 	}
 }
 

--- a/pkg/inet256ipv6/portal_config.go
+++ b/pkg/inet256ipv6/portal_config.go
@@ -40,10 +40,7 @@ func DefaultPortalConfig() PortalConfig {
 	if err != nil {
 		panic(err)
 	}
-	pkBytes, err := serde.MarshalPrivateKey(privKey)
-	if err != nil {
-		panic(err)
-	}
+	pkBytes := serde.MarshalPrivateKey(privKey)
 	pkb64str := base64.StdEncoding.EncodeToString(pkBytes)
 	return PortalConfig{
 		PrivateKey: pkb64str,

--- a/pkg/inet256srv/adapter.go
+++ b/pkg/inet256srv/adapter.go
@@ -9,22 +9,22 @@ import (
 
 // netAdapter converts an inet256.Network into a p2p.Swarm
 type netAdapter struct {
-	network Network
+	n Node
 }
 
-// SwarmFromNetwork converts a Network into a p2p.Swarm
-func SwarmFromNetwork(network Network) p2p.SecureSwarm {
+// SwarmFromNode converts a Network into a p2p.Swarm
+func SwarmFromNode(n Node) p2p.SecureSwarm {
 	return &netAdapter{
-		network: network,
+		n: n,
 	}
 }
 
 func (s *netAdapter) Tell(ctx context.Context, dst p2p.Addr, v p2p.IOVec) error {
-	return s.network.Tell(ctx, dst.(inet256.Addr), p2p.VecBytes(nil, v))
+	return s.n.Tell(ctx, dst.(inet256.Addr), p2p.VecBytes(nil, v))
 }
 
 func (s *netAdapter) Receive(ctx context.Context, fn p2p.TellHandler) error {
-	return s.network.Receive(ctx, func(msg inet256.Message) {
+	return s.n.Receive(ctx, func(msg inet256.Message) {
 		fn(p2p.Message{
 			Src:     msg.Src,
 			Dst:     msg.Dst,
@@ -34,23 +34,23 @@ func (s *netAdapter) Receive(ctx context.Context, fn p2p.TellHandler) error {
 }
 
 func (s *netAdapter) LocalAddrs() []p2p.Addr {
-	return []p2p.Addr{inet256.NewAddr(s.network.PublicKey())}
+	return []p2p.Addr{inet256.NewAddr(s.n.PublicKey())}
 }
 
 func (s *netAdapter) PublicKey() p2p.PublicKey {
-	return s.network.PublicKey()
+	return s.n.PublicKey()
 }
 
 func (s *netAdapter) LookupPublicKey(ctx context.Context, target p2p.Addr) (p2p.PublicKey, error) {
-	return s.network.LookupPublicKey(ctx, target.(inet256.Addr))
+	return s.n.LookupPublicKey(ctx, target.(inet256.Addr))
 }
 
 func (s *netAdapter) MTU(ctx context.Context, target p2p.Addr) int {
-	return s.network.MTU(ctx, target.(inet256.Addr))
+	return s.n.MTU(ctx, target.(inet256.Addr))
 }
 
 func (s *netAdapter) Close() error {
-	return s.network.Close()
+	return s.n.Close()
 }
 
 func (s *netAdapter) MaxIncomingSize() int {

--- a/pkg/inet256srv/server.go
+++ b/pkg/inet256srv/server.go
@@ -113,7 +113,7 @@ func (s *Server) CreateNode(ctx context.Context, privateKey p2p.PrivateKey) (Nod
 	return node, nil
 }
 
-func (s *Server) DeleteNode(privateKey p2p.PrivateKey) error {
+func (s *Server) DeleteNode(ctx context.Context, privateKey p2p.PrivateKey) error {
 	id := inet256.NewAddr(privateKey.Public())
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/inet256srv/server.go
+++ b/pkg/inet256srv/server.go
@@ -9,7 +9,6 @@ import (
 	"github.com/brendoncarroll/go-p2p/s/memswarm"
 	"github.com/brendoncarroll/go-p2p/s/multiswarm"
 	"github.com/inet256/inet256/pkg/inet256"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -40,7 +39,8 @@ type Server struct {
 	mainNode     Node
 
 	mu    sync.Mutex
-	nodes map[inet256.Addr]Node
+	nodes map[inet256.Addr]*rcNode
+	rcs   map[inet256.Addr]int
 
 	log *logrus.Logger
 }
@@ -68,7 +68,8 @@ func NewServer(params Params) *Server {
 			Networks:   params.Networks,
 			Peers:      ChainPeerStore{memPeers, params.Peers},
 		}),
-		nodes: make(map[inet256.Addr]Node),
+		nodes: make(map[inet256.Addr]*rcNode),
+		rcs:   make(map[inet256.Addr]int),
 		log:   logrus.StandardLogger(),
 	}
 	return s
@@ -76,11 +77,13 @@ func NewServer(params Params) *Server {
 
 func (s *Server) CreateNode(ctx context.Context, privateKey p2p.PrivateKey) (Node, error) {
 	id := inet256.NewAddr(privateKey.Public())
-	n, err := func() (Node, error) {
+	node, err := func() (Node, error) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		if _, exists := s.nodes[id]; exists {
-			return nil, errors.Errorf("node already exists")
+		if node, exists := s.nodes[id]; exists {
+			s.rcs[id]++
+			s.log.WithFields(logrus.Fields{"addr": id, "count": s.rcs[id]}).Infof("opened ref to node")
+			return node, nil
 		}
 		swarm := s.memrealm.NewSwarmWithKey(privateKey)
 
@@ -98,35 +101,29 @@ func (s *Server) CreateNode(ctx context.Context, privateKey p2p.PrivateKey) (Nod
 				nameMemSwarm: swarm,
 			},
 		})
-		s.nodes[id] = n
-		return n, nil
+		rcn := &rcNode{node: n.(*node), s: s}
+		s.nodes[id] = rcn
+		s.rcs[id] = 1
+		s.log.WithFields(logrus.Fields{"addr": id, "count": s.rcs[id]}).Infof("created node")
+		return rcn, nil
 	}()
 	if err != nil {
 		return nil, err
 	}
-	if err := n.Bootstrap(ctx); err != nil {
-		return nil, errors.Wrapf(err, "while bootstrapping node")
-	}
-	s.log.WithFields(logrus.Fields{"addr": id}).Info("created node")
-	return n, nil
+	return node, nil
 }
 
 func (s *Server) DeleteNode(privateKey p2p.PrivateKey) error {
 	id := inet256.NewAddr(privateKey.Public())
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	n, exists := s.nodes[id]
+	rcn, exists := s.nodes[id]
 	if !exists {
 		return nil
 	}
-	log := s.log.WithFields(logrus.Fields{"addr": id})
-	err := n.Close()
-	if err != nil {
-		log.Errorf("error closing node %v", err)
-	}
-	s.mainMemPeers.Remove(id)
+	err := rcn.node.Close()
+	delete(s.rcs, id)
 	delete(s.nodes, id)
-	log.Infof("deleted node")
 	return err
 }
 
@@ -177,7 +174,36 @@ func (s *Server) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, n := range s.nodes {
-		n.Close()
+		n.node.Close()
 	}
-	return s.mainNode.Close()
+	s.mainNode.Close()
+	s.rcs = make(map[inet256.Addr]int)
+	s.nodes = make(map[inet256.Addr]*rcNode)
+	return nil
+}
+
+type rcNode struct {
+	*node
+	s *Server
+}
+
+func (rcn *rcNode) Close() error {
+	s := rcn.s
+	id := rcn.node.LocalAddr()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rcs[id]--
+	log := s.log.WithFields(logrus.Fields{"addr": id, "count": s.rcs[id]})
+	if s.rcs[id] < 1 {
+		if err := rcn.node.Close(); err != nil {
+			log.Warnf("error closing %v", err)
+		}
+		delete(s.nodes, id)
+		delete(s.rcs, id)
+		s.mainMemPeers.Remove(id)
+		log.Infof("deleted node")
+	} else {
+		log.Info("dropped ref to node")
+	}
+	return nil
 }

--- a/pkg/inet256srv/server_test.go
+++ b/pkg/inet256srv/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/brendoncarroll/go-p2p"
 	"github.com/brendoncarroll/go-p2p/p2ptest"
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/inet256/inet256/pkg/inet256srv"
@@ -12,7 +13,7 @@ import (
 )
 
 func TestServerLoopback(t *testing.T) {
-	s := inet256test.NewTestServer(t, inet256srv.OneHopFactory)
+	s := inet256srv.NewTestServer(t, inet256srv.OneHopFactory)
 	mainNode := s.MainNode()
 	inet256test.TestSendRecvOne(t, mainNode, mainNode)
 
@@ -31,7 +32,7 @@ func TestServerLoopback(t *testing.T) {
 }
 
 func TestServerOneHop(t *testing.T) {
-	s := inet256test.NewTestServer(t, inet256srv.OneHopFactory)
+	s := inet256srv.NewTestServer(t, inet256srv.OneHopFactory)
 	main := s.MainNode()
 
 	const N = 5
@@ -53,7 +54,7 @@ func TestServerOneHop(t *testing.T) {
 
 func TestServerCreateDelete(t *testing.T) {
 	ctx := context.Background()
-	s := inet256test.NewTestServer(t, inet256srv.OneHopFactory)
+	s := inet256srv.NewTestServer(t, inet256srv.OneHopFactory)
 
 	const N = 100
 	for i := 0; i < N; i++ {
@@ -67,4 +68,20 @@ func TestServerCreateDelete(t *testing.T) {
 		err := s.DeleteNode(pk)
 		require.NoError(t, err)
 	}
+}
+
+func getMainAddr(x inet256.Service) inet256.Addr {
+	addr, err := x.(*inet256srv.Server).MainAddr()
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}
+
+func getTransportAddrs(x inet256.Service) []p2p.Addr {
+	addrs, err := x.(*inet256srv.Server).TransportAddrs()
+	if err != nil {
+		panic(err)
+	}
+	return addrs
 }

--- a/pkg/inet256srv/server_test.go
+++ b/pkg/inet256srv/server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/brendoncarroll/go-p2p"
 	"github.com/brendoncarroll/go-p2p/p2ptest"
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/inet256/inet256/pkg/inet256srv"
@@ -65,23 +64,7 @@ func TestServerCreateDelete(t *testing.T) {
 
 	for i := 0; i < N; i++ {
 		pk := p2ptest.NewTestKey(t, i)
-		err := s.DeleteNode(pk)
+		err := s.DeleteNode(ctx, pk)
 		require.NoError(t, err)
 	}
-}
-
-func getMainAddr(x inet256.Service) inet256.Addr {
-	addr, err := x.(*inet256srv.Server).MainAddr()
-	if err != nil {
-		panic(err)
-	}
-	return addr
-}
-
-func getTransportAddrs(x inet256.Service) []p2p.Addr {
-	addrs, err := x.(*inet256srv.Server).TransportAddrs()
-	if err != nil {
-		panic(err)
-	}
-	return addrs
 }

--- a/pkg/inet256srv/swarm.go
+++ b/pkg/inet256srv/swarm.go
@@ -192,7 +192,7 @@ func (s swarmWrapper) Close() error {
 }
 
 func newSecureNetwork(privateKey inet256.PrivateKey, x Network) Network {
-	insecSwarm := SwarmFromNetwork(x)
+	insecSwarm := SwarmFromNode(x)
 	fingerprinter := func(pubKey inet256.PublicKey) p2p.PeerID {
 		return p2p.PeerID(inet256.NewAddr(pubKey))
 	}

--- a/pkg/inet256srv/testserver.go
+++ b/pkg/inet256srv/testserver.go
@@ -1,0 +1,77 @@
+package inet256srv
+
+import (
+	"math"
+	"testing"
+
+	"github.com/brendoncarroll/go-p2p"
+	"github.com/brendoncarroll/go-p2p/p2ptest"
+	"github.com/brendoncarroll/go-p2p/s/memswarm"
+	"github.com/inet256/inet256/pkg/inet256"
+	"github.com/stretchr/testify/require"
+)
+
+func NewTestServer(t testing.TB, nf inet256.NetworkFactory) *Server {
+	pk := p2ptest.NewTestKey(t, math.MaxInt32)
+	ps := NewPeerStore()
+	s := NewServer(Params{
+		Networks:   map[NetworkCode]inet256.NetworkFactory{{}: nf},
+		Peers:      ps,
+		PrivateKey: pk,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, s.Close())
+	})
+	return s
+}
+
+func NewTestServers(t *testing.T, nf inet256.NetworkFactory, xs []inet256.Service) {
+	r := memswarm.NewRealm()
+	stores := make([]inet256.PeerStore, len(xs))
+	srvs := make([]*Server, len(xs))
+	for i := range srvs {
+		pk := p2ptest.NewTestKey(t, math.MaxInt32+i)
+		stores[i] = NewPeerStore()
+		srvs[i] = NewServer(Params{
+			Swarms: map[string]p2p.Swarm{
+				"external": r.NewSwarmWithKey(pk),
+			},
+			Networks:   map[NetworkCode]inet256.NetworkFactory{{}: nf},
+			Peers:      stores[i],
+			PrivateKey: pk,
+		})
+	}
+	for i := range srvs {
+		for j := range srvs {
+			if i == j {
+				continue
+			}
+			stores[i].Add(getMainAddr(srvs[j]))
+			stores[i].SetAddrs(getMainAddr(srvs[j]), getTransportAddrs(srvs[j]))
+		}
+	}
+	t.Cleanup(func() {
+		for _, s := range srvs {
+			require.NoError(t, s.Close())
+		}
+	})
+	for i := range xs {
+		xs[i] = srvs[i]
+	}
+}
+
+func getMainAddr(x *Server) inet256.Addr {
+	addr, err := x.MainAddr()
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}
+
+func getTransportAddrs(x *Server) []p2p.Addr {
+	addrs, err := x.TransportAddrs()
+	if err != nil {
+		panic(err)
+	}
+	return addrs
+}

--- a/pkg/inet256test/network.go
+++ b/pkg/inet256test/network.go
@@ -19,6 +19,7 @@ import (
 
 type (
 	Addr           = inet256.Addr
+	Node           = inet256.Node
 	Network        = inet256.Network
 	NetworkFactory = inet256.NetworkFactory
 	PeerStore      = inet256.PeerStore
@@ -71,7 +72,7 @@ func TestSendRecvAll(t testing.TB, nets []Network) {
 	})
 }
 
-func TestSendRecvOne(t testing.TB, src, dst Network) {
+func TestSendRecvOne(t testing.TB, src, dst Node) {
 	ctx, cf := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cf()
 

--- a/pkg/serde/serde.go
+++ b/pkg/serde/serde.go
@@ -8,8 +8,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func MarshalPrivateKey(privKey p2p.PrivateKey) ([]byte, error) {
-	return x509.MarshalPKCS8PrivateKey(privKey)
+func MarshalPrivateKey(privKey p2p.PrivateKey) []byte {
+	data, err := x509.MarshalPKCS8PrivateKey(privKey)
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 func ParsePrivateKey(data []byte) (p2p.PrivateKey, error) {
@@ -25,10 +29,7 @@ func ParsePrivateKey(data []byte) (p2p.PrivateKey, error) {
 }
 
 func MarshalPrivateKeyPEM(privateKey p2p.PrivateKey) ([]byte, error) {
-	data, err := MarshalPrivateKey(privateKey)
-	if err != nil {
-		return nil, err
-	}
+	data := MarshalPrivateKey(privateKey)
 	privKeyPEM := pem.EncodeToMemory(&pem.Block{
 		Type:  "PRIVATE KEY",
 		Bytes: data,


### PR DESCRIPTION
The `inet256test` package now exposes a function for testing service implementations directly.
Adds documentation to `inet256.Node` and `inet256.Service` indicating they are required by the spec.
Removes error returned from `serde.MarshalPrivateKey` which should always succeed if the key was parsed by `ParsePrivateKey`