### PR TITLE
Default API endpoint is UNIX socket.

### DIFF
--- a/client/go/inet256client/client.go
+++ b/client/go/inet256client/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/inet256/inet256/pkg/inet256mem"
 )
 
-const DefaultAPIEndpoint = "http://127.0.0.1:2560/nodes/"
+const DefaultAPIEndpoint = "unix:///run/inet256.sock"
 
 type (
 	Addr = inet256.Addr
@@ -26,11 +26,7 @@ func NewClient(endpoint string) (inet256.Service, error) {
 // If you are looking for a inet256.Service constructor, this is probably the one you want.
 // It checks the environment variable `INET256_API`
 func NewEnvClient() (inet256.Service, error) {
-	endpoint, yes := os.LookupEnv("INET256_API")
-	if !yes {
-		endpoint = DefaultAPIEndpoint
-	}
-	return NewClient(endpoint)
+	return NewClient(GetAPIEndpointFromEnv())
 }
 
 // NewPacketConn wraps the Node n in an adapter exposing the net.PacketConn interface instead.
@@ -41,4 +37,14 @@ func NewPacketConn(n inet256.Node) net.PacketConn {
 // NewTestService can be used to spawn an inet256 service without any peering for use in tests
 func NewTestService(t testing.TB) inet256.Service {
 	return inet256mem.New()
+}
+
+// GetAPIEndpointFromEnv looks for an API endpoint in the environment variable INET256_API.
+// If no such variable exists it falls back to DefaultAPIEndpoint
+func GetAPIEndpointFromEnv() string {
+	endpoint, yes := os.LookupEnv("INET256_API")
+	if !yes {
+		endpoint = DefaultAPIEndpoint
+	}
+	return endpoint
 }

--- a/doc/22_Daemon_Config.md
+++ b/doc/22_Daemon_Config.md
@@ -32,7 +32,7 @@ The endpoint that the daemon will listen at, to serve the INET256 API.
 
 e.g.
 ```yaml
-api_endpoint: "127.0.0.1:2560"
+api_endpoint: "unix:///run/inet256.sock"
 ```
 
 ## `transports`
@@ -85,22 +85,6 @@ network:
   beaconnet: {}
 ```
 `beaconnet` exposes no additional parameters so it's specification is just the empty object.
-
-Here is an example of 2 networks, using the same algorithm with different parameters.
-`multi` is a network which nests other network specs, and multiplexes them onto the transport layer.
-```yaml
-network:
-  multi:
-    "n1":
-        algo1:
-            param1: 1
-    "n2":
-        algo1:
-            param1: 2
-```
-- `n1` and `n2` are the network `codes` (used for multiplexing).
-- `algo1` is the name of the network algorithm.
-- `param1` is a parameter specific to `algo1`. The parameter `param1` is set to different values in each instantiation.
 
 Network algorithms have to be compiled into the daemon to be used.
 The `ls-networks` command in the CLI can be used to list the networks the daemon implements.

--- a/doc/31_IP6_Portal.md
+++ b/doc/31_IP6_Portal.md
@@ -21,5 +21,3 @@ The operating system receives the packet as regular IPv6 traffic, so any applica
 > If you are developing a new application which depends on INET256, it is highly recommended that you consume the INET256 API directly.
 It is generally not safe to assume that IPv6 traffic is confidential, although it would be when using the portal.
 If you mess up an address, or start serving traffic on a different IPv6 address, then you are at risk of communicating insecurely.
-At that point INET256 is just providing stable addresses (which is maybe all you want), but the other big reason to use it is to inherit security from the network layer.
-

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -51,7 +51,7 @@ type side struct {
 	i             int
 	dir           string
 	privateKey    inet256.PrivateKey
-	apiPort       int
+	apiEndpoint   string
 	transportPort int
 
 	d *inet256d.Daemon
@@ -60,12 +60,11 @@ type side struct {
 func newSide(t testing.TB, i int) *side {
 	dir := t.TempDir()
 	privateKey := inet256test.NewPrivateKey(t, i)
-	apiPort := 25600 + i
 	transportPort := 32000 + i
 
 	config := inet256d.DefaultConfig()
 	config.PrivateKeyPath = "./private_key.pem"
-	config.APIEndpoint = "http://127.0.0.1:" + strconv.Itoa(apiPort)
+	config.APIEndpoint = fmt.Sprintf("unix://%s/inet256-%d.sock", dir, i)
 	config.Transports = []inet256d.TransportSpec{
 		newUDPTransportSpec("127.0.0.1:" + strconv.Itoa(transportPort)),
 	}
@@ -82,7 +81,7 @@ func newSide(t testing.TB, i int) *side {
 		i:             i,
 		dir:           dir,
 		privateKey:    privateKey,
-		apiPort:       apiPort,
+		apiEndpoint:   config.APIEndpoint,
 		transportPort: transportPort,
 	}
 }
@@ -128,7 +127,7 @@ func (s *side) localAddr() inet256.Addr {
 }
 
 func (s *side) newClient(t testing.TB) inet256.Service {
-	client, err := inet256client.NewClient("http://127.0.0.1:" + strconv.Itoa(s.apiPort) + "/nodes/")
+	client, err := inet256client.NewClient(s.apiEndpoint)
 	require.NoError(t, err)
 	return client
 }

--- a/etc/systemd/inet256.service
+++ b/etc/systemd/inet256.service
@@ -5,7 +5,9 @@ After=inet256-init-config.service
 
 [Service]
 Restart=always
+ExecStartPre=-rm /run/inet256.sock
 ExecStart=inet256 daemon --config=/etc/inet256/config.yml
+ExecStopPost=-rm /run/inet256.sock
 ProtectHome=true
 ProtectSystem=true
 SyslogIdentifier=inet256

--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -1,7 +1,6 @@
 # Echo Example
 
-A config has already been provided with `inet256 create-config > config.yml`
-
+A config has already been provided with `inet256 create-config --api_endpoint=tcp://127.0.0.1:2560 > config.yml`.
 Generate your own key with `inet256 keygen > private_key.pem`
 
 Now run the daemon, let that sit in one terminal.
@@ -12,8 +11,8 @@ inet256 daemon --config=config.yml
 In another terminal run the echo server.
 This will connect to the daemon through the API and the daemon will manage the node.
 The echo command does not run it's own node.
-```
-inet256 echo
+```shell
+$ INET256_API=tcp://127.0.0.1:2560 inet256 echo
 ```
 
 The first log line is the address of the echo server. We will need that in a minute
@@ -21,8 +20,9 @@ The first log line is the address of the echo server. We will need that in a min
 In another terminal (3rd one, last one) run the nc command.  Use the echo servers address as the first argument.
 This will also connect to the daemon.
 This process does not run it's own node.
-```
-inet256 nc <echo server address>
+
+```shell
+$ INET256_API=tcp://127.0.0.1:2560 inet256 nc <echo server address>
 ```
 
 Now try typing something, everything should be echoed back to you.

--- a/examples/echo/config.yml
+++ b/examples/echo/config.yml
@@ -1,5 +1,5 @@
 private_key_path: "./private_key.pem"
-api_addr: 127.0.0.1:2560
+api_addr: tcp://127.0.0.1:2560
 network:
   beaconnet: {}
 transports:

--- a/pkg/inet256cmd/daemon.go
+++ b/pkg/inet256cmd/daemon.go
@@ -38,18 +38,23 @@ func newDaemonCmd() *cobra.Command {
 }
 
 func newCreateConfigCmd() *cobra.Command {
-	return &cobra.Command{
+	c := &cobra.Command{
 		Use:   "create-config",
 		Short: "creates a new default config and writes it to stdout",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := inet256d.DefaultConfig()
-			data, err := yaml.Marshal(c)
-			if err != nil {
-				return err
-			}
-			out := cmd.OutOrStdout()
-			out.Write(data)
-			return nil
-		},
 	}
+	api_endpoint := c.Flags().String("api_endpoint", "", "--api_endpoint=tcp://127.0.0.1:2560")
+	c.RunE = func(cmd *cobra.Command, args []string) error {
+		c := inet256d.DefaultConfig()
+		if *api_endpoint != "" {
+			c.APIEndpoint = *api_endpoint
+		}
+		data, err := yaml.Marshal(c)
+		if err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+		out.Write(data)
+		return nil
+	}
+	return c
 }

--- a/pkg/inet256cmd/keygen.go
+++ b/pkg/inet256cmd/keygen.go
@@ -2,7 +2,7 @@ package inet256cmd
 
 import (
 	"crypto/rand"
-	"io/ioutil"
+	"os"
 
 	"github.com/inet256/inet256/pkg/inet256"
 	"github.com/inet256/inet256/pkg/serde"
@@ -62,7 +62,7 @@ func generateKey() inet256.PrivateKey {
 }
 
 func loadPrivateKeyFromFile(p string) (inet256.PrivateKey, error) {
-	data, err := ioutil.ReadFile(p)
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/inet256cmd/root.go
+++ b/pkg/inet256cmd/root.go
@@ -13,7 +13,7 @@ import (
 	"github.com/inet256/inet256/pkg/inet256ipv6"
 )
 
-const defaultAPIAddr = "http://127.0.0.1:2560"
+const defaultAPIAddr = inet256d.DefaultAPIEndpoint
 
 var ctx = func() context.Context {
 	ctx := context.Background()
@@ -31,7 +31,7 @@ func NewRootCmd() *cobra.Command {
 		return inet256client.NewEnvClient()
 	}
 	newAdminClient := func() (inet256d.AdminClient, error) {
-		return inet256d.NewAdminClient(defaultAPIAddr + "/admin")
+		return inet256d.NewAdminClient(inet256client.GetAPIEndpointFromEnv())
 	}
 	newNode := func(ctx context.Context, privateKey inet256.PrivateKey) (inet256.Node, error) {
 		c, err := newClient()

--- a/pkg/inet256d/config.go
+++ b/pkg/inet256d/config.go
@@ -23,7 +23,7 @@ import (
 	"github.com/inet256/inet256/pkg/serde"
 )
 
-const DefaultAPIEndpoint = "http://127.0.0.1:2560"
+const DefaultAPIEndpoint = "unix:///run/inet256.sock"
 
 type PeerSpec struct {
 	ID    inet256.Addr `yaml:"id"`

--- a/pkg/inet256http/inet256http_test.go
+++ b/pkg/inet256http/inet256http_test.go
@@ -32,7 +32,7 @@ func TestOpen(t *testing.T) {
 	})
 	eg.Go(func() error {
 		defer l.Close()
-		endpoint := "http://" + l.Addr().String() + "/"
+		endpoint := "tcp://" + l.Addr().String()
 		t.Log(endpoint)
 		c, err := NewClient(endpoint)
 		if err != nil {
@@ -76,7 +76,7 @@ func newTestService(t testing.TB, x inet256.Service) inet256.Service {
 			t.Log(err)
 		}
 	}()
-	c, err := NewClient("http://" + l.Addr().String() + "/")
+	c, err := NewClient("tcp://" + l.Addr().String() + "/")
 	require.NoError(t, err)
 	return c
 }

--- a/pkg/inet256http/server.go
+++ b/pkg/inet256http/server.go
@@ -3,7 +3,7 @@ package inet256http
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -48,7 +48,7 @@ func (s *Server) handleOpen(w http.ResponseWriter, r *http.Request) (hijacked bo
 	if err != nil {
 		return hijacked, err
 	}
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return hijacked, err
 	}


### PR DESCRIPTION
- Adds support for `unix` and `tcp` API endpoints.
- Removes support for `http` API endpoints.  HTTP is the only protocol, but it can be layered on `tcp` or `unix`.  The endpoint scheme configures the transport protocol.
- Changes systemd service to manage cleaning up the socket before and after the service starts.